### PR TITLE
Remove macro use from expanded code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
             let name = format!("{ident}");
             load_checks.push(quote! {
                 if #ident.is_empty() {
-                    anyhow::bail!(#name.to_string() + "must be specified");
+                    return Err(anyhow::Error::msg(#name.to_string() + "must be specified"));
                 }
             });
             load_where.push(format!("{ident} = ANY(${bind})"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,8 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
     let load_params = tokens(load_params);
     let load_fields = tokens(load_fields);
     let delete_fields = tokens(delete_fields);
+    let load_sql = format!("SELECT * FROM {table_name} WHERE {load_where}");
+    let delete_sql = format!("DELETE FROM {table_name} WHERE {load_where} RETURNING *");
 
     // decompress
     let mut decompress_fields = Vec::new();
@@ -258,6 +260,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
     } else {
         quote! {}
     };
+    let store_sql = format!("COPY {table_name} ({store_fields}) FROM STDIN BINARY");
 
     quote! {
         #item
@@ -274,7 +277,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
             /// rows outside the requested time range.
             pub async fn load(db: &deadpool_postgres::Object, #load_filters) -> anyhow::Result<Vec<#packed_name>> {
                 #load_checks
-                let sql = format!("SELECT * FROM {} WHERE {}", #table_name, #load_where);
+                let sql = #load_sql;
                 let mut results = Vec::new();
                 for row in db.query(&db.prepare_cached(&sql).await?, &[#load_params]).await? {
                     results.push(#packed_name { #load_fields });
@@ -288,7 +291,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
             /// rows outside the requested time range.
             pub async fn delete(db: &deadpool_postgres::Object, #load_filters) -> anyhow::Result<Vec<#packed_name>> {
                 #load_checks
-                let sql = format!("DELETE FROM {} WHERE {} RETURNING *", #table_name, #load_where);
+                let sql = #delete_sql;
                 let mut results = Vec::new();
                 for row in db.query(&db.prepare_cached(&sql).await?, &[#load_params]).await? {
                     results.push(#packed_name { #delete_fields });
@@ -319,7 +322,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
                 for row in rows {
                     grouped_rows.entry((#store_group)).or_default().push(row);
                 }
-                let sql = format!("COPY {} ({}) FROM STDIN BINARY", #table_name, #store_fields);
+                let sql = #store_sql;
                 let types = &[#store_types];
                 let stmt = db.copy_in(&db.prepare_cached(&sql).await?).await?;
                 let writer = tokio_postgres::binary_copy::BinaryCopyInWriter::new(stmt, types);

--- a/tests/expand/boolean.expanded.rs
+++ b/tests/expand/boolean.expanded.rs
@@ -27,14 +27,7 @@ impl CompressedQueryStats {
                 error
             });
         }
-        let sql = ::alloc::__export::must_use({
-            ::alloc::fmt::format(
-                format_args!(
-                    "SELECT * FROM {0} WHERE {1}", "query_stats",
-                    "database_id = ANY($1)",
-                ),
-            )
-        });
+        let sql = "SELECT * FROM query_stats WHERE database_id = ANY($1)";
         let mut results = Vec::new();
         for row in db.query(&db.prepare_cached(&sql).await?, &[&database_id]).await? {
             results
@@ -63,14 +56,7 @@ impl CompressedQueryStats {
                 error
             });
         }
-        let sql = ::alloc::__export::must_use({
-            ::alloc::fmt::format(
-                format_args!(
-                    "DELETE FROM {0} WHERE {1} RETURNING *", "query_stats",
-                    "database_id = ANY($1)",
-                ),
-            )
-        });
+        let sql = "DELETE FROM query_stats WHERE database_id = ANY($1) RETURNING *";
         let mut results = Vec::new();
         for row in db.query(&db.prepare_cached(&sql).await?, &[&database_id]).await? {
             results
@@ -120,14 +106,7 @@ impl CompressedQueryStats {
         for row in rows {
             grouped_rows.entry((row.database_id,)).or_default().push(row);
         }
-        let sql = ::alloc::__export::must_use({
-            ::alloc::fmt::format(
-                format_args!(
-                    "COPY {0} ({1}) FROM STDIN BINARY", "query_stats",
-                    "database_id, toplevel, calls",
-                ),
-            )
-        });
+        let sql = "COPY query_stats (database_id, toplevel, calls) FROM STDIN BINARY";
         let types = &[
             tokio_postgres::types::Type::INT8,
             tokio_postgres::types::Type::BYTEA,

--- a/tests/expand/boolean.expanded.rs
+++ b/tests/expand/boolean.expanded.rs
@@ -19,13 +19,9 @@ impl CompressedQueryStats {
         database_id: &[i64],
     ) -> anyhow::Result<Vec<CompressedQueryStats>> {
         if database_id.is_empty() {
-            return ::anyhow::__private::Err({
-                use ::anyhow::__private::kind::*;
-                let error = match "database_id".to_string() + "must be specified" {
-                    error => (&error).anyhow_kind().new(error),
-                };
-                error
-            });
+            return Err(
+                anyhow::Error::msg("database_id".to_string() + "must be specified"),
+            );
         }
         let sql = "SELECT * FROM query_stats WHERE database_id = ANY($1)";
         let mut results = Vec::new();
@@ -48,13 +44,9 @@ impl CompressedQueryStats {
         database_id: &[i64],
     ) -> anyhow::Result<Vec<CompressedQueryStats>> {
         if database_id.is_empty() {
-            return ::anyhow::__private::Err({
-                use ::anyhow::__private::kind::*;
-                let error = match "database_id".to_string() + "must be specified" {
-                    error => (&error).anyhow_kind().new(error),
-                };
-                error
-            });
+            return Err(
+                anyhow::Error::msg("database_id".to_string() + "must be specified"),
+            );
         }
         let sql = "DELETE FROM query_stats WHERE database_id = ANY($1) RETURNING *";
         let mut results = Vec::new();

--- a/tests/expand/float_round.expanded.rs
+++ b/tests/expand/float_round.expanded.rs
@@ -27,14 +27,7 @@ impl CompressedQueryStats {
                 error
             });
         }
-        let sql = ::alloc::__export::must_use({
-            ::alloc::fmt::format(
-                format_args!(
-                    "SELECT * FROM {0} WHERE {1}", "query_stats",
-                    "database_id = ANY($1)",
-                ),
-            )
-        });
+        let sql = "SELECT * FROM query_stats WHERE database_id = ANY($1)";
         let mut results = Vec::new();
         for row in db.query(&db.prepare_cached(&sql).await?, &[&database_id]).await? {
             results
@@ -63,14 +56,7 @@ impl CompressedQueryStats {
                 error
             });
         }
-        let sql = ::alloc::__export::must_use({
-            ::alloc::fmt::format(
-                format_args!(
-                    "DELETE FROM {0} WHERE {1} RETURNING *", "query_stats",
-                    "database_id = ANY($1)",
-                ),
-            )
-        });
+        let sql = "DELETE FROM query_stats WHERE database_id = ANY($1) RETURNING *";
         let mut results = Vec::new();
         for row in db.query(&db.prepare_cached(&sql).await?, &[&database_id]).await? {
             results
@@ -121,14 +107,7 @@ impl CompressedQueryStats {
         for row in rows {
             grouped_rows.entry((row.database_id,)).or_default().push(row);
         }
-        let sql = ::alloc::__export::must_use({
-            ::alloc::fmt::format(
-                format_args!(
-                    "COPY {0} ({1}) FROM STDIN BINARY", "query_stats",
-                    "database_id, calls, total_time",
-                ),
-            )
-        });
+        let sql = "COPY query_stats (database_id, calls, total_time) FROM STDIN BINARY";
         let types = &[
             tokio_postgres::types::Type::INT8,
             tokio_postgres::types::Type::BYTEA,

--- a/tests/expand/float_round.expanded.rs
+++ b/tests/expand/float_round.expanded.rs
@@ -19,13 +19,9 @@ impl CompressedQueryStats {
         database_id: &[i64],
     ) -> anyhow::Result<Vec<CompressedQueryStats>> {
         if database_id.is_empty() {
-            return ::anyhow::__private::Err({
-                use ::anyhow::__private::kind::*;
-                let error = match "database_id".to_string() + "must be specified" {
-                    error => (&error).anyhow_kind().new(error),
-                };
-                error
-            });
+            return Err(
+                anyhow::Error::msg("database_id".to_string() + "must be specified"),
+            );
         }
         let sql = "SELECT * FROM query_stats WHERE database_id = ANY($1)";
         let mut results = Vec::new();
@@ -48,13 +44,9 @@ impl CompressedQueryStats {
         database_id: &[i64],
     ) -> anyhow::Result<Vec<CompressedQueryStats>> {
         if database_id.is_empty() {
-            return ::anyhow::__private::Err({
-                use ::anyhow::__private::kind::*;
-                let error = match "database_id".to_string() + "must be specified" {
-                    error => (&error).anyhow_kind().new(error),
-                };
-                error
-            });
+            return Err(
+                anyhow::Error::msg("database_id".to_string() + "must be specified"),
+            );
         }
         let sql = "DELETE FROM query_stats WHERE database_id = ANY($1) RETURNING *";
         let mut results = Vec::new();

--- a/tests/expand/query_stats.expanded.rs
+++ b/tests/expand/query_stats.expanded.rs
@@ -42,13 +42,9 @@ impl CompressedQueryStats {
         filter_end: SystemTime,
     ) -> anyhow::Result<Vec<CompressedQueryStats>> {
         if database_id.is_empty() {
-            return ::anyhow::__private::Err({
-                use ::anyhow::__private::kind::*;
-                let error = match "database_id".to_string() + "must be specified" {
-                    error => (&error).anyhow_kind().new(error),
-                };
-                error
-            });
+            return Err(
+                anyhow::Error::msg("database_id".to_string() + "must be specified"),
+            );
         }
         let sql = "SELECT * FROM query_stats WHERE database_id = ANY($1) AND end_at >= $2 AND start_at <= $3";
         let mut results = Vec::new();
@@ -92,13 +88,9 @@ impl CompressedQueryStats {
         filter_end: SystemTime,
     ) -> anyhow::Result<Vec<CompressedQueryStats>> {
         if database_id.is_empty() {
-            return ::anyhow::__private::Err({
-                use ::anyhow::__private::kind::*;
-                let error = match "database_id".to_string() + "must be specified" {
-                    error => (&error).anyhow_kind().new(error),
-                };
-                error
-            });
+            return Err(
+                anyhow::Error::msg("database_id".to_string() + "must be specified"),
+            );
         }
         let sql = "DELETE FROM query_stats WHERE database_id = ANY($1) AND end_at >= $2 AND start_at <= $3 RETURNING *";
         let mut results = Vec::new();

--- a/tests/expand/query_stats.expanded.rs
+++ b/tests/expand/query_stats.expanded.rs
@@ -50,14 +50,7 @@ impl CompressedQueryStats {
                 error
             });
         }
-        let sql = ::alloc::__export::must_use({
-            ::alloc::fmt::format(
-                format_args!(
-                    "SELECT * FROM {0} WHERE {1}", "query_stats",
-                    "database_id = ANY($1) AND end_at >= $2 AND start_at <= $3",
-                ),
-            )
-        });
+        let sql = "SELECT * FROM query_stats WHERE database_id = ANY($1) AND end_at >= $2 AND start_at <= $3";
         let mut results = Vec::new();
         for row in db
             .query(
@@ -107,14 +100,7 @@ impl CompressedQueryStats {
                 error
             });
         }
-        let sql = ::alloc::__export::must_use({
-            ::alloc::fmt::format(
-                format_args!(
-                    "DELETE FROM {0} WHERE {1} RETURNING *", "query_stats",
-                    "database_id = ANY($1) AND end_at >= $2 AND start_at <= $3",
-                ),
-            )
-        });
+        let sql = "DELETE FROM query_stats WHERE database_id = ANY($1) AND end_at >= $2 AND start_at <= $3 RETURNING *";
         let mut results = Vec::new();
         for row in db
             .query(
@@ -255,14 +241,7 @@ impl CompressedQueryStats {
         for row in rows {
             grouped_rows.entry((row.database_id,)).or_default().push(row);
         }
-        let sql = ::alloc::__export::must_use({
-            ::alloc::fmt::format(
-                format_args!(
-                    "COPY {0} ({1}) FROM STDIN BINARY", "query_stats",
-                    "database_id, start_at, end_at, collected_at, collected_secs, fingerprint, postgres_role_id, calls, rows, total_time, io_time, shared_blks_hit, shared_blks_read",
-                ),
-            )
-        });
+        let sql = "COPY query_stats (database_id, start_at, end_at, collected_at, collected_secs, fingerprint, postgres_role_id, calls, rows, total_time, io_time, shared_blks_hit, shared_blks_read) FROM STDIN BINARY";
         let types = &[
             tokio_postgres::types::Type::INT8,
             tokio_postgres::types::Type::TIMESTAMPTZ,


### PR DESCRIPTION
Avoiding macros inside of the generated code makes the result easier to read