### PR TITLE
Update macrotest docs and usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,14 @@
 # Contributing to `pco_store`
 
+## Running tests
+
+Because this crate is a procedural macro, we commit expanded versions of the code to make changes easier to review.
+
+To run the tests and rewrite the expanded files:
+```sh
+MACROTEST=overwrite cargo test
+```
+
 ## Environment Setup
 
 To get started working on `pco_store`, you need to be able to run the tests.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -6,10 +6,7 @@ use std::time::{Duration, SystemTime};
 
 #[test]
 fn macrotest() {
-    macrotest::expand("tests/expand/query_stats.rs");
-    macrotest::expand("tests/expand/boolean.rs");
-    macrotest::expand("tests/expand/no_group_by.rs");
-    macrotest::expand("tests/expand/float_round.rs");
+    macrotest::expand("tests/expand/*.rs");
 }
 
 pub static DB_POOL: std::sync::LazyLock<std::sync::Arc<deadpool_postgres::Pool>> = std::sync::LazyLock::new(|| {


### PR DESCRIPTION
This documents how to regenerate the macro-expanded test files, and also simplifies the calling code using a file glob.