### PR TITLE
Generalize database types to accept deref'd ClientWrapper

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
             ///
             /// For models with a timestamp, [decompress][Self::decompress] automatically filters out
             /// rows outside the requested time range.
-            pub async fn load(db: &deadpool_postgres::Object, #load_filters) -> anyhow::Result<Vec<#packed_name>> {
+            pub async fn load(db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>, #load_filters) -> anyhow::Result<Vec<#packed_name>> {
                 #load_checks
                 let sql = #load_sql;
                 let mut results = Vec::new();
@@ -289,7 +289,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
             ///
             /// For models with a timestamp, [decompress][Self::decompress] **will not** filter out
             /// rows outside the requested time range.
-            pub async fn delete(db: &deadpool_postgres::Object, #load_filters) -> anyhow::Result<Vec<#packed_name>> {
+            pub async fn delete(db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>, #load_filters) -> anyhow::Result<Vec<#packed_name>> {
                 #load_checks
                 let sql = #delete_sql;
                 let mut results = Vec::new();
@@ -314,7 +314,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
             }
 
             /// Writes the data to disk.
-            pub async fn store(db: &deadpool_postgres::Object, rows: Vec<#name>) -> anyhow::Result<()> {
+            pub async fn store(db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>, rows: Vec<#name>) -> anyhow::Result<()> {
                 if rows.is_empty() {
                     return Ok(());
                 }
@@ -340,7 +340,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
             /// This can be used to improve the compression ratio and reduce read IO, for example
             /// by compacting real-time data into a single row per hour / day / week.
             pub async fn store_grouped<F, R>(
-                db: &deadpool_postgres::Object,
+                db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
                 rows: Vec<#name>,
                 grouping: F,
             ) -> anyhow::Result<()>

--- a/tests/expand/boolean.expanded.rs
+++ b/tests/expand/boolean.expanded.rs
@@ -15,7 +15,7 @@ impl CompressedQueryStats {
     /// For models with a timestamp, [decompress][Self::decompress] automatically filters out
     /// rows outside the requested time range.
     pub async fn load(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         database_id: &[i64],
     ) -> anyhow::Result<Vec<CompressedQueryStats>> {
         if database_id.is_empty() {
@@ -40,7 +40,7 @@ impl CompressedQueryStats {
     /// For models with a timestamp, [decompress][Self::decompress] **will not** filter out
     /// rows outside the requested time range.
     pub async fn delete(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         database_id: &[i64],
     ) -> anyhow::Result<Vec<CompressedQueryStats>> {
         if database_id.is_empty() {
@@ -88,7 +88,7 @@ impl CompressedQueryStats {
     }
     /// Writes the data to disk.
     pub async fn store(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<QueryStat>,
     ) -> anyhow::Result<()> {
         if rows.is_empty() {
@@ -139,7 +139,7 @@ impl CompressedQueryStats {
     /// This can be used to improve the compression ratio and reduce read IO, for example
     /// by compacting real-time data into a single row per hour / day / week.
     pub async fn store_grouped<F, R>(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<QueryStat>,
         grouping: F,
     ) -> anyhow::Result<()>

--- a/tests/expand/float_round.expanded.rs
+++ b/tests/expand/float_round.expanded.rs
@@ -15,7 +15,7 @@ impl CompressedQueryStats {
     /// For models with a timestamp, [decompress][Self::decompress] automatically filters out
     /// rows outside the requested time range.
     pub async fn load(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         database_id: &[i64],
     ) -> anyhow::Result<Vec<CompressedQueryStats>> {
         if database_id.is_empty() {
@@ -40,7 +40,7 @@ impl CompressedQueryStats {
     /// For models with a timestamp, [decompress][Self::decompress] **will not** filter out
     /// rows outside the requested time range.
     pub async fn delete(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         database_id: &[i64],
     ) -> anyhow::Result<Vec<CompressedQueryStats>> {
         if database_id.is_empty() {
@@ -89,7 +89,7 @@ impl CompressedQueryStats {
     }
     /// Writes the data to disk.
     pub async fn store(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<QueryStat>,
     ) -> anyhow::Result<()> {
         if rows.is_empty() {
@@ -143,7 +143,7 @@ impl CompressedQueryStats {
     /// This can be used to improve the compression ratio and reduce read IO, for example
     /// by compacting real-time data into a single row per hour / day / week.
     pub async fn store_grouped<F, R>(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<QueryStat>,
         grouping: F,
     ) -> anyhow::Result<()>

--- a/tests/expand/no_group_by.expanded.rs
+++ b/tests/expand/no_group_by.expanded.rs
@@ -15,7 +15,7 @@ impl CompressedQueryStats {
     /// For models with a timestamp, [decompress][Self::decompress] automatically filters out
     /// rows outside the requested time range.
     pub async fn load(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
     ) -> anyhow::Result<Vec<CompressedQueryStats>> {
         let sql = "SELECT * FROM query_stats WHERE true";
         let mut results = Vec::new();
@@ -34,7 +34,7 @@ impl CompressedQueryStats {
     /// For models with a timestamp, [decompress][Self::decompress] **will not** filter out
     /// rows outside the requested time range.
     pub async fn delete(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
     ) -> anyhow::Result<Vec<CompressedQueryStats>> {
         let sql = "DELETE FROM query_stats WHERE true RETURNING *";
         let mut results = Vec::new();
@@ -84,7 +84,7 @@ impl CompressedQueryStats {
     }
     /// Writes the data to disk.
     pub async fn store(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<QueryStat>,
     ) -> anyhow::Result<()> {
         if rows.is_empty() {
@@ -139,7 +139,7 @@ impl CompressedQueryStats {
     /// This can be used to improve the compression ratio and reduce read IO, for example
     /// by compacting real-time data into a single row per hour / day / week.
     pub async fn store_grouped<F, R>(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<QueryStat>,
         grouping: F,
     ) -> anyhow::Result<()>

--- a/tests/expand/query_stats.expanded.rs
+++ b/tests/expand/query_stats.expanded.rs
@@ -36,7 +36,7 @@ impl CompressedQueryStats {
     /// For models with a timestamp, [decompress][Self::decompress] automatically filters out
     /// rows outside the requested time range.
     pub async fn load(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         database_id: &[i64],
         filter_start: SystemTime,
         filter_end: SystemTime,
@@ -82,7 +82,7 @@ impl CompressedQueryStats {
     /// For models with a timestamp, [decompress][Self::decompress] **will not** filter out
     /// rows outside the requested time range.
     pub async fn delete(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         database_id: &[i64],
         filter_start: SystemTime,
         filter_end: SystemTime,
@@ -223,7 +223,7 @@ impl CompressedQueryStats {
     }
     /// Writes the data to disk.
     pub async fn store(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<QueryStat>,
     ) -> anyhow::Result<()> {
         if rows.is_empty() {
@@ -341,7 +341,7 @@ impl CompressedQueryStats {
     /// This can be used to improve the compression ratio and reduce read IO, for example
     /// by compacting real-time data into a single row per hour / day / week.
     pub async fn store_grouped<F, R>(
-        db: &deadpool_postgres::Object,
+        db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<QueryStat>,
         grouping: F,
     ) -> anyhow::Result<()>


### PR DESCRIPTION
This adjusts generated code to be more liberal in accepting any type that dereferences to `ClientWrapper`. This happens to already be the case for `deadpool_postgres::Object`, so this strictly makes the code more general. The generality is useful in updating another codebase to allow for different connection types.

**Note on AI:** Claude was used in this PR to make the changes, although the decision/design was created by hand. Claude was also used to clean up the test expectations. Outputs were all verified after generation.