### PR TITLE
Support storing a String for every row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,8 @@ version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -486,6 +488,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +582,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -758,15 +776,19 @@ dependencies = [
  "futures",
  "macrotest",
  "pco",
+ "postgres-types",
  "proc-macro2",
  "quote",
  "serde",
+ "serde-brief",
  "serde_json",
  "serde_with",
  "serial_test",
  "syn",
  "tokio",
  "tokio-postgres",
+ "uuid",
+ "zeekstd",
 ]
 
 [[package]]
@@ -806,10 +828,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "postgres-protocol"
-version = "0.6.8"
+name = "pkg-config"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ff0abab4a9b844b93ef7b81f1efc0a366062aaef2cd702c76256b5dc075c54"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "postgres-derive"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56df96f5394370d1b20e49de146f9e6c25aa9ae750f449c9d665eafecb3ccae6"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
 dependencies = [
  "base64",
  "byteorder",
@@ -825,14 +865,16 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
+checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
 dependencies = [
  "bytes",
  "chrono",
  "fallible-iterator",
+ "postgres-derive",
  "postgres-protocol",
+ "uuid",
 ]
 
 [[package]]
@@ -1022,6 +1064,15 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-brief"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4002dfcbc73b5a7b10879d700aa607216be2461f0403afbdf8780b51f2ee81d6"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1440,6 +1491,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
+name = "uuid"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1761,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
+name = "zeekstd"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5f1379c45a7b52ed4aa3442da2cf5cc39abf1d8d178a5c02797be29c072ede2"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,3 +1794,22 @@ name = "zmij"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,18 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 serde_with = "3.16"
 syn = "2.0"
-tokio-postgres = { version = "0.7", features = ["with-chrono-0_4"] }
+tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-uuid-1"] }
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 dotenvy = "0.15"
 macrotest = "1.1"
+postgres-types = { version = "0.2", features = ["derive"] }
+serde-brief = { version = "0.2", features = ["alloc"] }
 serial_test = "3.2"
 tokio = { version = "1.43", features = ["full"] }
+uuid = { version = "1.20", features = ["serde"] }
+zeekstd = "0.6"
 
 [[bench]]
 name = "bucket_size"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ pco_store extends that with support for:
 - `chrono::DateTime`, `std::time::SystemTime`
 - `bool`
 - `uuid::Uuid` (only as a `group_by` field)
-- `String` (only as a `group_by` field)
+- `String`
+
+For binary types like `String`, additional dependencies are needed:
+
+```toml
+serde-brief = { version = "0.2", features = ["alloc"] }
+zeekstd = "0.6"
+```
 
 ## Performance
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,9 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
     for field in model.fields.iter() {
         let ident = field.ident.clone().unwrap();
         let ty_original = field.ty.clone();
+        let ty_original_s = quote! { #ty_original }.to_string();
         let mut ty = field.ty.clone();
-        let round_float_field = float_round.is_some() && quote! { #ty }.to_string().starts_with("f");
+        let round_float_field = float_round.is_some() && ty_original_s.starts_with("f");
         if group_by.iter().any(|i| *i == ident) {
             decompressed_fields.push(quote! { #ident: self.#ident.clone(), });
         } else {
@@ -139,14 +140,27 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
             if round_float_field {
                 ty = Type::Verbatim(quote! { i64 });
             }
-            if quote! { #ty_original }.to_string() == "bool" {
+            if ty_original_s == "bool" {
                 ty = Type::Verbatim(quote! { u16 });
             }
+            let decompress_field = if ty_original_s == "String" {
+                quote! {
+                    {
+                        let cursor = std::io::Cursor::new(&self.#ident);
+                        let mut decoder = zeekstd::Decoder::new(cursor).context("zeekstd::Decoder")?;
+                        let mut bytes = Vec::new();
+                        std::io::copy(&mut decoder, &mut bytes).context("io::copy")?;
+                        serde_brief::from_slice(&bytes).context("serde_brief::from_slice")?
+                    }
+                }
+            } else {
+                quote! { ::pco::standalone::simple_decompress(&self.#ident)? }
+            };
             decompress_fields.push(quote! {
                 let #ident: Vec<#ty> = if self.#ident.is_empty() {
                     Vec::new()
                 } else {
-                    ::pco::standalone::simple_decompress(&self.#ident)?
+                    #decompress_field
                 };
             });
             compressed_field_sizes.push(quote! { #ident.len(), });
@@ -167,7 +181,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
                 decompressed_fields.push(quote! {
                     #ident: #ident.get(index).cloned().unwrap_or_default() as #ty_original / #float_round as #ty_original,
                 });
-            } else if quote! { #ty_original }.to_string() == "bool" {
+            } else if ty_original_s == "bool" {
                 decompressed_fields.push(quote! {
                     #ident: #ident.get(index).cloned().unwrap_or_default() == 1,
                 });
@@ -190,12 +204,13 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
     for field in model.fields.iter() {
         let ident = field.ident.clone().unwrap();
         let ty_original = field.ty.clone();
+        let ty_original_s = quote! { #ty_original }.to_string();
         let mut ty = field.ty.clone();
-        let round_float_field = float_round.is_some() && quote! { #ty }.to_string().starts_with("f");
+        let round_float_field = float_round.is_some() && ty_original_s.starts_with("f");
         if round_float_field {
             ty = Type::Verbatim(quote! { i64 });
         }
-        if quote! { #ty_original }.to_string() == "bool" {
+        if ty_original_s == "bool" {
             ty = Type::Verbatim(quote! { u16 });
         }
         if group_by.iter().any(|i| *i == ident) {
@@ -219,16 +234,36 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
             store_types.push(Ident::new("BYTEA", Span::call_site()));
             let expr = if round_float_field {
                 quote! { (r.#ident * #float_round as #ty_original).round() as i64 }
-            } else if quote! { #ty_original }.to_string() == "bool" {
+            } else if ty_original_s == "bool" {
                 quote! { r.#ident as u16 }
+            } else if ty_original_s == "String" {
+                // TODO: needless clone here since we're consuming the rows
+                // That could be avoided with a for loop that inserts into each Vec,
+                // consuming the row with `let QueryStat { f1, f2 } = row` at the start.
+                quote! { r.#ident.clone() }
             } else {
                 quote! { r.#ident }
             };
-            store_values.push(quote! {
-                &::pco::standalone::simpler_compress(
-                    &rows.iter().map(|r| #expr).collect::<Vec<_>>(), ::pco::DEFAULT_COMPRESSION_LEVEL
-                ).unwrap(),
-            });
+            let data = quote! { rows.iter().map(|r| #expr).collect::<Vec<_>>() };
+            if ty_original_s == "String" {
+                store_values.push(quote! {
+                    &{
+                        use std::io::Write;
+                        let bytes = serde_brief::to_vec(&#data).context("serde_brief::to_slice")?;
+                        let mut compressed_bytes = Vec::new();
+                        let mut encoder = zeekstd::Encoder::new(&mut compressed_bytes).context("zeekstd::Encoder")?;
+                        encoder.write_all(&bytes).context("encoder.write_all")?;
+                        encoder.finish().context("encoder.finish")?;
+                        compressed_bytes
+                    },
+                });
+            } else {
+                store_values.push(quote! {
+                    &::pco::standalone::simpler_compress(
+                        &#data, ::pco::DEFAULT_COMPRESSION_LEVEL
+                    )?,
+                });
+            }
         }
     }
     let store_fields = store_fields.join(", ");
@@ -306,6 +341,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
 
             /// Decompresses a group of data points.
             pub fn decompress(self) -> anyhow::Result<Vec<#name>> {
+                use anyhow::Context;
                 let mut results = Vec::new();
                 #decompress_fields
                 let len = [#compressed_field_sizes].into_iter().max().unwrap_or(0);
@@ -320,6 +356,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
 
             /// Writes the data to disk.
             pub async fn store(db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>, rows: Vec<#name>) -> anyhow::Result<()> {
+                use anyhow::Context;
                 if rows.is_empty() {
                     return Ok(());
                 }
@@ -353,6 +390,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
                 F: Fn(&#name) -> R,
                 R: Eq + std::hash::Hash,
             {
+                use anyhow::Context;
                 if rows.is_empty() {
                     return Ok(());
                 }

--- a/tests/expand/boolean.expanded.rs
+++ b/tests/expand/boolean.expanded.rs
@@ -64,6 +64,7 @@ impl CompressedQueryStats {
     }
     /// Decompresses a group of data points.
     pub fn decompress(self) -> anyhow::Result<Vec<QueryStat>> {
+        use anyhow::Context;
         let mut results = Vec::new();
         let toplevel: Vec<u16> = if self.toplevel.is_empty() {
             Vec::new()
@@ -93,6 +94,7 @@ impl CompressedQueryStats {
         db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<QueryStat>,
     ) -> anyhow::Result<()> {
+        use anyhow::Context;
         if rows.is_empty() {
             return Ok(());
         }
@@ -120,15 +122,13 @@ impl CompressedQueryStats {
                     &[
                         &rows[0].database_id,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.toplevel as u16).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.toplevel as u16).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                     ],
                 )
                 .await?;
@@ -149,6 +149,7 @@ impl CompressedQueryStats {
         F: Fn(&QueryStat) -> R,
         R: Eq + std::hash::Hash,
     {
+        use anyhow::Context;
         if rows.is_empty() {
             return Ok(());
         }
@@ -179,15 +180,13 @@ impl CompressedQueryStats {
                     &[
                         &rows[0].database_id,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.toplevel as u16).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.toplevel as u16).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                     ],
                 )
                 .await?;

--- a/tests/expand/float_round.expanded.rs
+++ b/tests/expand/float_round.expanded.rs
@@ -64,6 +64,7 @@ impl CompressedQueryStats {
     }
     /// Decompresses a group of data points.
     pub fn decompress(self) -> anyhow::Result<Vec<QueryStat>> {
+        use anyhow::Context;
         let mut results = Vec::new();
         let calls: Vec<i64> = if self.calls.is_empty() {
             Vec::new()
@@ -94,6 +95,7 @@ impl CompressedQueryStats {
         db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<QueryStat>,
     ) -> anyhow::Result<()> {
+        use anyhow::Context;
         if rows.is_empty() {
             return Ok(());
         }
@@ -121,18 +123,16 @@ impl CompressedQueryStats {
                     &[
                         &rows[0].database_id,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| (r.total_time * 100f32 as f64).round() as i64)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows
+                                .iter()
+                                .map(|r| (r.total_time * 100f32 as f64).round() as i64)
+                                .collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                     ],
                 )
                 .await?;
@@ -153,6 +153,7 @@ impl CompressedQueryStats {
         F: Fn(&QueryStat) -> R,
         R: Eq + std::hash::Hash,
     {
+        use anyhow::Context;
         if rows.is_empty() {
             return Ok(());
         }
@@ -183,18 +184,16 @@ impl CompressedQueryStats {
                     &[
                         &rows[0].database_id,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| (r.total_time * 100f32 as f64).round() as i64)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows
+                                .iter()
+                                .map(|r| (r.total_time * 100f32 as f64).round() as i64)
+                                .collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                     ],
                 )
                 .await?;

--- a/tests/expand/no_group_by.expanded.rs
+++ b/tests/expand/no_group_by.expanded.rs
@@ -52,6 +52,7 @@ impl CompressedQueryStats {
     }
     /// Decompresses a group of data points.
     pub fn decompress(self) -> anyhow::Result<Vec<QueryStat>> {
+        use anyhow::Context;
         let mut results = Vec::new();
         let database_id: Vec<i64> = if self.database_id.is_empty() {
             Vec::new()
@@ -89,6 +90,7 @@ impl CompressedQueryStats {
         db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<QueryStat>,
     ) -> anyhow::Result<()> {
+        use anyhow::Context;
         if rows.is_empty() {
             return Ok(());
         }
@@ -115,20 +117,17 @@ impl CompressedQueryStats {
                 .write(
                     &[
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.database_id).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.database_id).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.total_time).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.total_time).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                     ],
                 )
                 .await?;
@@ -149,6 +148,7 @@ impl CompressedQueryStats {
         F: Fn(&QueryStat) -> R,
         R: Eq + std::hash::Hash,
     {
+        use anyhow::Context;
         if rows.is_empty() {
             return Ok(());
         }
@@ -175,20 +175,17 @@ impl CompressedQueryStats {
                 .write(
                     &[
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.database_id).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.database_id).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.total_time).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.total_time).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                     ],
                 )
                 .await?;

--- a/tests/expand/query_stats.expanded.rs
+++ b/tests/expand/query_stats.expanded.rs
@@ -104,6 +104,7 @@ impl CompressedQueryStats {
     }
     /// Decompresses a group of data points.
     pub fn decompress(self) -> anyhow::Result<Vec<QueryStat>> {
+        use anyhow::Context;
         let mut results = Vec::new();
         let collected_at: Vec<u64> = if self.collected_at.is_empty() {
             Vec::new()
@@ -202,6 +203,7 @@ impl CompressedQueryStats {
         db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<QueryStat>,
     ) -> anyhow::Result<()> {
+        use anyhow::Context;
         if rows.is_empty() {
             return Ok(());
         }
@@ -258,56 +260,41 @@ impl CompressedQueryStats {
                             )
                             .unwrap(),
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.collected_secs).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.collected_secs).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.fingerprint).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.fingerprint).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| r.postgres_role_id)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.postgres_role_id).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.rows).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.rows).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.total_time).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.total_time).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.io_time).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.io_time).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.shared_blks_hit).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.shared_blks_hit).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| r.shared_blks_read)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.shared_blks_read).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                     ],
                 )
                 .await?;
@@ -328,6 +315,7 @@ impl CompressedQueryStats {
         F: Fn(&QueryStat) -> R,
         R: Eq + std::hash::Hash,
     {
+        use anyhow::Context;
         if rows.is_empty() {
             return Ok(());
         }
@@ -387,56 +375,41 @@ impl CompressedQueryStats {
                             )
                             .unwrap(),
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.collected_secs).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.collected_secs).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.fingerprint).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.fingerprint).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| r.postgres_role_id)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.postgres_role_id).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.rows).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.rows).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.total_time).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.total_time).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.io_time).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.io_time).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.shared_blks_hit).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.shared_blks_hit).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| r.shared_blks_read)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.shared_blks_read).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                     ],
                 )
                 .await?;

--- a/tests/expand/query_stats_chrono.expanded.rs
+++ b/tests/expand/query_stats_chrono.expanded.rs
@@ -104,6 +104,7 @@ impl CompressedQueryStats {
     }
     /// Decompresses a group of data points.
     pub fn decompress(self) -> anyhow::Result<Vec<QueryStat>> {
+        use anyhow::Context;
         let mut results = Vec::new();
         let collected_at: Vec<u64> = if self.collected_at.is_empty() {
             Vec::new()
@@ -204,6 +205,7 @@ impl CompressedQueryStats {
         db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<QueryStat>,
     ) -> anyhow::Result<()> {
+        use anyhow::Context;
         if rows.is_empty() {
             return Ok(());
         }
@@ -255,56 +257,41 @@ impl CompressedQueryStats {
                             )
                             .unwrap(),
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.collected_secs).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.collected_secs).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.fingerprint).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.fingerprint).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| r.postgres_role_id)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.postgres_role_id).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.rows).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.rows).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.total_time).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.total_time).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.io_time).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.io_time).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.shared_blks_hit).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.shared_blks_hit).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| r.shared_blks_read)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.shared_blks_read).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                     ],
                 )
                 .await?;
@@ -325,6 +312,7 @@ impl CompressedQueryStats {
         F: Fn(&QueryStat) -> R,
         R: Eq + std::hash::Hash,
     {
+        use anyhow::Context;
         if rows.is_empty() {
             return Ok(());
         }
@@ -379,56 +367,41 @@ impl CompressedQueryStats {
                             )
                             .unwrap(),
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.collected_secs).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.collected_secs).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.fingerprint).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.fingerprint).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| r.postgres_role_id)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.postgres_role_id).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.calls).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.rows).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.rows).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.total_time).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.total_time).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.io_time).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.io_time).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.shared_blks_hit).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.shared_blks_hit).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| r.shared_blks_read)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.shared_blks_read).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                     ],
                 )
                 .await?;

--- a/tests/expand/system_storage_stats.expanded.rs
+++ b/tests/expand/system_storage_stats.expanded.rs
@@ -17,7 +17,7 @@ pub struct CompressedSystemStorageStats {
     filter: Option<Filter>,
     server_id: Uuid,
     granularity: i32,
-    mountpoint: String,
+    mountpoint: Vec<u8>,
     collected_at: Vec<u8>,
     bytes_available: Vec<u8>,
     bytes_total: Vec<u8>,
@@ -42,16 +42,13 @@ impl CompressedSystemStorageStats {
         if filter.granularity.is_empty() {
             return Err(anyhow::Error::msg("granularity".to_string() + " is required"));
         }
-        if filter.mountpoint.is_empty() {
-            return Err(anyhow::Error::msg("mountpoint".to_string() + " is required"));
-        }
         if filter.collected_at.is_none() {
             return Err(anyhow::Error::msg("collected_at".to_string() + " is required"));
         }
         filter.range_truncate()?;
         let sql = "SELECT ".to_string() + fields.select().as_str() + " FROM "
             + "system_storage_stats" + " WHERE "
-            + "server_id = ANY($1) AND granularity = ANY($2) AND mountpoint = ANY($3) AND end_at >= $4 AND start_at <= $5";
+            + "server_id = ANY($1) AND granularity = ANY($2) AND end_at >= $3 AND start_at <= $4";
         let mut results = Vec::new();
         for row in db
             .query(
@@ -59,7 +56,6 @@ impl CompressedSystemStorageStats {
                 &[
                     &filter.server_id,
                     &filter.granularity,
-                    &filter.mountpoint,
                     filter.collected_at.as_ref().unwrap().start(),
                     filter.collected_at.as_ref().unwrap().end(),
                 ],
@@ -88,15 +84,12 @@ impl CompressedSystemStorageStats {
         if filter.granularity.is_empty() {
             return Err(anyhow::Error::msg("granularity".to_string() + " is required"));
         }
-        if filter.mountpoint.is_empty() {
-            return Err(anyhow::Error::msg("mountpoint".to_string() + " is required"));
-        }
         if filter.collected_at.is_none() {
             return Err(anyhow::Error::msg("collected_at".to_string() + " is required"));
         }
         filter.range_truncate()?;
         let sql = "DELETE FROM ".to_string() + "system_storage_stats" + " WHERE "
-            + "server_id = ANY($1) AND granularity = ANY($2) AND mountpoint = ANY($3) AND end_at >= $4 AND start_at <= $5"
+            + "server_id = ANY($1) AND granularity = ANY($2) AND end_at >= $3 AND start_at <= $4"
             + " RETURNING " + fields.select().as_str();
         let mut results = Vec::new();
         for row in db
@@ -105,7 +98,6 @@ impl CompressedSystemStorageStats {
                 &[
                     &filter.server_id,
                     &filter.granularity,
-                    &filter.mountpoint,
                     filter.collected_at.as_ref().unwrap().start(),
                     filter.collected_at.as_ref().unwrap().end(),
                 ],
@@ -118,7 +110,20 @@ impl CompressedSystemStorageStats {
     }
     /// Decompresses a group of data points.
     pub fn decompress(self) -> anyhow::Result<Vec<SystemStorageStat>> {
+        use anyhow::Context;
         let mut results = Vec::new();
+        let mountpoint: Vec<String> = if self.mountpoint.is_empty() {
+            Vec::new()
+        } else {
+            {
+                let cursor = std::io::Cursor::new(&self.mountpoint);
+                let mut decoder = zeekstd::Decoder::new(cursor)
+                    .context("zeekstd::Decoder")?;
+                let mut bytes = Vec::new();
+                std::io::copy(&mut decoder, &mut bytes).context("io::copy")?;
+                serde_brief::from_slice(&bytes).context("serde_brief::from_slice")?
+            }
+        };
         let collected_at: Vec<u64> = if self.collected_at.is_empty() {
             Vec::new()
         } else {
@@ -150,6 +155,7 @@ impl CompressedSystemStorageStats {
             ::pco::standalone::simple_decompress(&self.write_latency)?
         };
         let len = [
+            mountpoint.len(),
             collected_at.len(),
             bytes_available.len(),
             bytes_total.len(),
@@ -164,7 +170,7 @@ impl CompressedSystemStorageStats {
             let row = SystemStorageStat {
                 server_id: self.server_id.clone(),
                 granularity: self.granularity.clone(),
-                mountpoint: self.mountpoint.clone(),
+                mountpoint: mountpoint.get(index).cloned().unwrap_or_default(),
                 collected_at: chrono::DateTime::from_timestamp_micros(
                         collected_at[index] as i64,
                     )
@@ -188,17 +194,14 @@ impl CompressedSystemStorageStats {
         db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
         rows: Vec<SystemStorageStat>,
     ) -> anyhow::Result<()> {
+        use anyhow::Context;
         if rows.is_empty() {
             return Ok(());
         }
         let mut grouped_rows: ahash::AHashMap<_, Vec<SystemStorageStat>> = ahash::AHashMap::new();
         for row in rows {
             grouped_rows
-                .entry((
-                    row.server_id.clone(),
-                    row.granularity.clone(),
-                    row.mountpoint.clone(),
-                ))
+                .entry((row.server_id.clone(), row.granularity.clone()))
                 .or_default()
                 .push(row);
         }
@@ -206,7 +209,7 @@ impl CompressedSystemStorageStats {
         let types = &[
             tokio_postgres::types::Type::UUID,
             tokio_postgres::types::Type::INT4,
-            tokio_postgres::types::Type::TEXT,
+            tokio_postgres::types::Type::BYTEA,
             tokio_postgres::types::Type::TIMESTAMPTZ,
             tokio_postgres::types::Type::TIMESTAMPTZ,
             tokio_postgres::types::Type::BYTEA,
@@ -237,7 +240,24 @@ impl CompressedSystemStorageStats {
                     &[
                         &rows[0].server_id,
                         &rows[0].granularity,
-                        &rows[0].mountpoint,
+                        &{
+                            use std::io::Write;
+                            let bytes = serde_brief::to_vec(
+                                    &rows
+                                        .iter()
+                                        .map(|r| r.mountpoint.clone())
+                                        .collect::<Vec<_>>(),
+                                )
+                                .context("serde_brief::to_slice")?;
+                            let mut compressed_bytes = Vec::new();
+                            let mut encoder = zeekstd::Encoder::new(
+                                    &mut compressed_bytes,
+                                )
+                                .context("zeekstd::Encoder")?;
+                            encoder.write_all(&bytes).context("encoder.write_all")?;
+                            encoder.finish().context("encoder.finish")?;
+                            compressed_bytes
+                        },
                         &start_at,
                         &end_at,
                         &::pco::standalone::simpler_compress(
@@ -246,36 +266,31 @@ impl CompressedSystemStorageStats {
                             )
                             .unwrap(),
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.bytes_available).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.bytes_available).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.bytes_total).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.bytes_total).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.queue_depth).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.queue_depth).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| (r.read_latency * 100f32 as f64).round() as i64)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows
+                                .iter()
+                                .map(|r| (r.read_latency * 100f32 as f64).round() as i64)
+                                .collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| (r.write_latency * 100f32 as f64).round() as i64)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows
+                                .iter()
+                                .map(|r| (r.write_latency * 100f32 as f64).round() as i64)
+                                .collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                     ],
                 )
                 .await?;
@@ -296,18 +311,14 @@ impl CompressedSystemStorageStats {
         F: Fn(&SystemStorageStat) -> R,
         R: Eq + std::hash::Hash,
     {
+        use anyhow::Context;
         if rows.is_empty() {
             return Ok(());
         }
         let mut grouped_rows: ahash::AHashMap<_, Vec<SystemStorageStat>> = ahash::AHashMap::new();
         for row in rows {
             grouped_rows
-                .entry((
-                    row.server_id.clone(),
-                    row.granularity.clone(),
-                    row.mountpoint.clone(),
-                    grouping(&row),
-                ))
+                .entry((row.server_id.clone(), row.granularity.clone(), grouping(&row)))
                 .or_default()
                 .push(row);
         }
@@ -315,7 +326,7 @@ impl CompressedSystemStorageStats {
         let types = &[
             tokio_postgres::types::Type::UUID,
             tokio_postgres::types::Type::INT4,
-            tokio_postgres::types::Type::TEXT,
+            tokio_postgres::types::Type::BYTEA,
             tokio_postgres::types::Type::TIMESTAMPTZ,
             tokio_postgres::types::Type::TIMESTAMPTZ,
             tokio_postgres::types::Type::BYTEA,
@@ -346,7 +357,24 @@ impl CompressedSystemStorageStats {
                     &[
                         &rows[0].server_id,
                         &rows[0].granularity,
-                        &rows[0].mountpoint,
+                        &{
+                            use std::io::Write;
+                            let bytes = serde_brief::to_vec(
+                                    &rows
+                                        .iter()
+                                        .map(|r| r.mountpoint.clone())
+                                        .collect::<Vec<_>>(),
+                                )
+                                .context("serde_brief::to_slice")?;
+                            let mut compressed_bytes = Vec::new();
+                            let mut encoder = zeekstd::Encoder::new(
+                                    &mut compressed_bytes,
+                                )
+                                .context("zeekstd::Encoder")?;
+                            encoder.write_all(&bytes).context("encoder.write_all")?;
+                            encoder.finish().context("encoder.finish")?;
+                            compressed_bytes
+                        },
                         &start_at,
                         &end_at,
                         &::pco::standalone::simpler_compress(
@@ -355,36 +383,31 @@ impl CompressedSystemStorageStats {
                             )
                             .unwrap(),
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.bytes_available).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.bytes_available).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.bytes_total).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.bytes_total).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows.iter().map(|r| r.queue_depth).collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows.iter().map(|r| r.queue_depth).collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| (r.read_latency * 100f32 as f64).round() as i64)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows
+                                .iter()
+                                .map(|r| (r.read_latency * 100f32 as f64).round() as i64)
+                                .collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                         &::pco::standalone::simpler_compress(
-                                &rows
-                                    .iter()
-                                    .map(|r| (r.write_latency * 100f32 as f64).round() as i64)
-                                    .collect::<Vec<_>>(),
-                                ::pco::DEFAULT_COMPRESSION_LEVEL,
-                            )
-                            .unwrap(),
+                            &rows
+                                .iter()
+                                .map(|r| (r.write_latency * 100f32 as f64).round() as i64)
+                                .collect::<Vec<_>>(),
+                            ::pco::DEFAULT_COMPRESSION_LEVEL,
+                        )?,
                     ],
                 )
                 .await?;
@@ -1571,13 +1594,11 @@ impl Filter {
     pub fn new(
         server_id: &[Uuid],
         granularity: &[i32],
-        mountpoint: &[String],
         collected_at: std::ops::RangeInclusive<DateTime<Utc>>,
     ) -> Self {
         Self {
             server_id: server_id.into(),
             granularity: granularity.into(),
-            mountpoint: mountpoint.into(),
             collected_at: Some(collected_at),
             ..Self::default()
         }
@@ -1715,7 +1736,7 @@ impl Fields {
         Self {
             server_id: true,
             granularity: true,
-            mountpoint: true,
+            mountpoint: false,
             collected_at: true,
             bytes_available: false,
             bytes_total: false,
@@ -1725,6 +1746,7 @@ impl Fields {
         }
     }
     fn merge_filter(&mut self, filter: &Filter) {
+        (!filter.mountpoint.is_empty()).then(|| self.mountpoint = true);
         (!filter.bytes_available.is_empty()).then(|| self.bytes_available = true);
         (!filter.bytes_total.is_empty()).then(|| self.bytes_total = true);
         (!filter.queue_depth.is_empty()).then(|| self.queue_depth = true);

--- a/tests/expand/system_storage_stats.rs
+++ b/tests/expand/system_storage_stats.rs
@@ -1,9 +1,7 @@
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
-// Confirms that UUID and String types can be used in `group_by`
-
-#[pco_store::store(timestamp = collected_at, group_by = [server_id, granularity, mountpoint], float_round = 2)]
+#[pco_store::store(timestamp = collected_at, group_by = [server_id, granularity], float_round = 2)]
 pub struct SystemStorageStat {
     pub server_id: Uuid,
     pub granularity: i32,

--- a/tests/string_tests/mod.rs
+++ b/tests/string_tests/mod.rs
@@ -1,0 +1,69 @@
+use super::DB_POOL;
+use anyhow::Context;
+use chrono::{DateTime, Duration, Utc};
+use uuid::Uuid;
+
+#[pco_store::store(timestamp = collected_at, group_by = [server_id], float_round = 2)]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct SystemStorageStat {
+    pub server_id: Uuid,
+    pub collected_at: DateTime<Utc>,
+    pub mountpoint: String,
+    pub bytes: i64,
+    pub latency: f64,
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test() -> anyhow::Result<()> {
+    let db = &DB_POOL.get().await?;
+    let sql = "
+        DROP TABLE IF EXISTS system_storage_stats;
+        CREATE TABLE system_storage_stats (
+            server_id uuid NOT NULL,
+            start_at timestamptz NOT NULL,
+            end_at timestamptz NOT NULL,
+            collected_at bytea STORAGE EXTERNAL NOT NULL,
+            mountpoint bytea STORAGE EXTERNAL NOT NULL,
+            bytes bytea STORAGE EXTERNAL NOT NULL,
+            latency bytea STORAGE EXTERNAL NOT NULL
+        );
+        CREATE INDEX ON system_storage_stats USING btree (server_id, end_at, start_at);
+    ";
+    db.batch_execute(sql).await?;
+
+    let server_id = Uuid::default();
+    let t = DateTime::from_timestamp_micros(Utc::now().timestamp_micros()).context("out of range")?;
+    let t2 = t + Duration::seconds(1);
+    let s = SystemStorageStat { server_id, collected_at: t, ..Default::default() };
+    let s1 = SystemStorageStat { mountpoint: "/".into(), bytes: 1, latency: 1.0, ..s };
+    let s2 = SystemStorageStat { mountpoint: "/other".into(), bytes: 2, latency: 2.0, ..s };
+    let s3 = SystemStorageStat { mountpoint: "/".into(), bytes: 3, latency: 3.0, collected_at: t2, ..s };
+    let stats = vec![s1.clone(), s2.clone(), s3.clone()];
+    CompressedSystemStorageStats::store(db, stats.clone()).await?;
+
+    // Filtering by a single timestamp
+    let actual = load(db, Filter::new(&[server_id], t..=t)).await?;
+    assert_eq!(actual, vec![s1.clone(), s2.clone()]);
+
+    // Filtering the whole time range
+    let actual = load(db, Filter::new(&[server_id], t..=t2)).await?;
+    assert_eq!(actual, stats);
+
+    // Filtering by compressed String field
+    let mut filter = Filter::new(&[server_id], t..=t2);
+    filter.mountpoint = vec!["/other".into()];
+    let actual = load(db, filter).await?;
+    assert_eq!(actual, vec![s2.clone()]);
+
+    Ok(())
+}
+
+async fn load(db: &deadpool_postgres::Client, filter: Filter) -> anyhow::Result<Vec<SystemStorageStat>> {
+    let mut rows = Vec::new();
+    for group in CompressedSystemStorageStats::load(db, filter, ()).await? {
+        rows.extend(group.decompress()?);
+    }
+    rows.sort_by_key(|s| (s.bytes, s.collected_at));
+    Ok(rows)
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, SystemTime};
 mod chrono_tests;
 mod fields_tests;
 mod filter_tests;
+mod string_tests;
 
 #[test]
 fn macrotest() {
@@ -96,8 +97,7 @@ async fn timestamp() {
 
     // The `load` WHERE query and `decompress` timestamp filter work as expected
     let mut stat = QueryStat { database_id, collected_at: start, fingerprint: 1, calls: 1, total_time: 1.0 };
-    for e in 0..3 {
-        println!("{e}");
+    for _ in 0..3 {
         let mut stats = Vec::new();
         for _ in 1..=10 {
             stat.collected_at += Duration::from_secs(60);


### PR DESCRIPTION
This introduces two new dependencies ([also discussed here](https://github.com/pganalyze/pco_store/issues/9#issuecomment-3706242596)):
- serde-brief is used to encode/decode the underlying `Vec<String>`. This should be a good option for more complex non-numeric structures in the future
- postcard / rkyv?

TODO:
- [ ] [switch to postcard / rkyv](https://github.com/pganalyze/pco_store/issues/9#issuecomment-3892664668)