### PR TITLE
Iterator API v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "better_io"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92fde17f91e7ba10b2a07f8dff29530b77144894bc6ae850fbc66e1276af0d28"
+checksum = "ef0a3155e943e341e557863e69a708999c94ede624e37865c8e2a91b94efa78f"
 
 [[package]]
 name = "bitflags"
@@ -293,9 +293,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtype_dispatch"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a5ccdfd6c5e7e2fea9c5cf256f2a08216047fab19c621c3da64e9ae4a1462d"
+checksum = "ab23e69df104e2fd85ee63a533a22d2132ef5975dc6b36f9f3e5a7305e4a8ed7"
 
 [[package]]
 name = "dyn-clone"
@@ -736,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "pco"
-version = "0.4.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab068b64f2c6f074cbdcafc80ebd83a27da92a3848deba2fabc21eba6691fc65"
+checksum = "e89d71ab3c07ed898defa4915bdc2a963131d811a1eab0eeacfac65c94cdeae8"
 dependencies = [
  "better_io",
  "dtype_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ ahash = "0.8"
 anyhow = "1.0"
 deadpool-postgres = "0.14"
 futures = "0.3"
-pco = "0.4"
+pco = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/benches/synthetic.rs
+++ b/benches/synthetic.rs
@@ -135,16 +135,11 @@ pub async fn store() -> Result<Duration> {
 pub async fn load() -> Result<Duration> {
     let db = &DB_POOL.get().await.unwrap();
     let database_ids: Vec<i64> = db.query_one("SELECT array_agg(DISTINCT database_id) FROM synthetic_pco_stores", &[]).await?.get(0);
-    let mut stats = Vec::new();
     let filter = Filter::new(&database_ids, SystemTime::UNIX_EPOCH..=SystemTime::now());
 
     // This assumes the stats.push() call takes negligible time.
     let start = Instant::now();
-    for group in CompressedQueryStats::load(db, filter, ()).await? {
-        for stat in group.decompress()? {
-            stats.push(stat);
-        }
-    }
+    let _stats: Vec<QueryStat> = CompressedQueryStats::load(db, filter, ()).await?.collect::<Result<_>>()?;
     return Ok(start.elapsed());
 }
 
@@ -155,23 +150,22 @@ pub async fn load_reduce() -> Result<Duration> {
     let filter = Filter::new(&database_ids, SystemTime::UNIX_EPOCH..=SystemTime::now());
 
     let start = Instant::now();
-    for group in CompressedQueryStats::load(db, filter, ()).await? {
-        for stat in group.decompress()? {
-            let key = (stat.database_id, stat.fingerprint, stat.postgres_role_id);
-            let entry = stats.entry(key).or_default();
+    for stat in CompressedQueryStats::load(db, filter, ()).await? {
+        let stat = stat?;
+        let key = (stat.database_id, stat.fingerprint, stat.postgres_role_id);
+        let entry = stats.entry(key).or_default();
 
-            entry.database_id = stat.database_id;
-            entry.collected_at = stat.collected_at;
-            entry.collected_secs += stat.collected_secs;
-            entry.fingerprint = stat.fingerprint;
-            entry.postgres_role_id = stat.postgres_role_id;
-            entry.calls += stat.calls;
-            entry.rows += stat.rows;
-            entry.total_time += stat.total_time;
-            entry.io_time += stat.io_time;
-            entry.shared_blks_hit += stat.shared_blks_hit;
-            entry.shared_blks_read += stat.shared_blks_read;
-        }
+        entry.database_id = stat.database_id;
+        entry.collected_at = stat.collected_at;
+        entry.collected_secs += stat.collected_secs;
+        entry.fingerprint = stat.fingerprint;
+        entry.postgres_role_id = stat.postgres_role_id;
+        entry.calls += stat.calls;
+        entry.rows += stat.rows;
+        entry.total_time += stat.total_time;
+        entry.io_time += stat.io_time;
+        entry.shared_blks_hit += stat.shared_blks_hit;
+        entry.shared_blks_read += stat.shared_blks_read;
     }
 
     return Ok(start.elapsed());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,16 +122,18 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
     let load_params = tokens(load_params);
 
     // decompress
+    let mut decompress_field_names = vec![quote! { filter, }];
     let mut decompress_fields = Vec::new();
-    let mut compressed_field_sizes = Vec::new();
+    let mut decompress_fields_first = None;
     let mut decompressed_fields = Vec::new();
     for field in model.fields.iter() {
         let ident = field.ident.clone().unwrap();
         let ty_original = field.ty.clone();
         let mut ty = field.ty.clone();
         let round_float_field = float_round.is_some() && quote! { #ty }.to_string().starts_with("f");
+        decompress_field_names.push(quote! { #ident, });
         if group_by.iter().any(|i| *i == ident) {
-            decompressed_fields.push(quote! { #ident: self.#ident.clone(), });
+            decompressed_fields.push(quote! { #ident: #ident.clone(), });
         } else {
             if timestamp.as_ref().map(|t| *t == ident).unwrap_or(false) {
                 ty = Type::Verbatim(quote! { u64 });
@@ -143,21 +145,25 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
                 ty = Type::Verbatim(quote! { u16 });
             }
             decompress_fields.push(quote! {
-                let #ident: Vec<#ty> = if self.#ident.is_empty() {
+                let mut #ident: std::vec::IntoIter<#ty> = if #ident.is_empty() {
                     Vec::new()
                 } else {
-                    ::pco::standalone::simple_decompress(&self.#ident)?
-                };
+                    ::pco::standalone::simple_decompress(&#ident)?
+                }.into_iter();
             });
-            compressed_field_sizes.push(quote! { #ident.len(), });
+            let value = if decompress_fields_first.is_none() {
+                quote! { #ident }
+            } else {
+                quote! { #ident.next().unwrap_or_default() }
+            };
             if timestamp.as_ref().map(|t| *t == ident).unwrap_or(false) {
                 let value = if using_chrono {
                     quote! {
-                        chrono::DateTime::from_timestamp_micros(#ident[index] as i64).unwrap()
+                        chrono::DateTime::from_timestamp_micros(#value as i64).unwrap()
                     }
                 } else {
                     quote! {
-                        std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_micros(#ident[index])
+                        std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_micros(#value)
                     }
                 };
                 decompressed_fields.push(quote! {
@@ -165,21 +171,24 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
                 });
             } else if round_float_field {
                 decompressed_fields.push(quote! {
-                    #ident: #ident.get(index).cloned().unwrap_or_default() as #ty_original / #float_round as #ty_original,
+                    #ident: #value as #ty_original / #float_round as #ty_original,
                 });
             } else if quote! { #ty_original }.to_string() == "bool" {
                 decompressed_fields.push(quote! {
-                    #ident: #ident.get(index).cloned().unwrap_or_default() == 1,
+                    #ident: #value == 1,
                 });
             } else {
                 decompressed_fields.push(quote! {
-                    #ident: #ident.get(index).cloned().unwrap_or_default(),
+                    #ident: #value,
                 });
+            }
+            if decompress_fields_first.is_none() {
+                decompress_fields_first = Some(ident.clone());
             }
         }
     }
+    let decompress_field_names = tokens(decompress_field_names);
     let decompress_fields = tokens(decompress_fields);
-    let compressed_field_sizes = tokens(compressed_field_sizes);
     let decompressed_fields = tokens(decompressed_fields);
 
     // store
@@ -212,7 +221,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
             store_types.push(Ident::new("BYTEA", Span::call_site()));
             store_values.push(quote! {
                 &start_at, &end_at,
-                &::pco::standalone::simpler_compress(&#timestamp, ::pco::DEFAULT_COMPRESSION_LEVEL).unwrap(),
+                &::pco::standalone::simple_compress(&#timestamp, &Default::default()).unwrap(),
             });
         } else {
             store_fields.push(ident.to_string());
@@ -225,8 +234,8 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
                 quote! { r.#ident }
             };
             store_values.push(quote! {
-                &::pco::standalone::simpler_compress(
-                    &rows.iter().map(|r| #expr).collect::<Vec<_>>(), ::pco::DEFAULT_COMPRESSION_LEVEL
+                &::pco::standalone::simple_compress(
+                    &rows.iter().map(|r| #expr).collect::<Vec<_>>(), &Default::default()
                 ).unwrap(),
             });
         }
@@ -273,7 +282,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
                 db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
                 mut filter: Filter,
                 fields: impl TryInto<Fields>
-            ) -> anyhow::Result<Vec<#packed_name>> {
+            ) -> anyhow::Result<impl Iterator<Item = anyhow::Result<#name>>> {
                 let mut fields = fields.try_into().map_err(|_| anyhow::Error::msg("unknown field"))?;
                 fields.merge_filter(&filter);
                 #load_checks
@@ -282,7 +291,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
                 for row in db.query(&db.prepare_cached(&sql).await?, &[#load_params]).await? {
                     results.push(fields.load_from_row(row, Some(filter.clone()))?);
                 }
-                Ok(results)
+                QueryStatsIterator::new(results)
             }
 
             /// Deletes data for the specified filters, returning it to the caller.
@@ -292,7 +301,7 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
                 db: &impl ::std::ops::Deref<Target = deadpool_postgres::ClientWrapper>,
                 mut filter: Filter,
                 fields: impl TryInto<Fields>
-            ) -> anyhow::Result<Vec<#packed_name>> {
+            ) -> anyhow::Result<impl Iterator<Item = anyhow::Result<#name>>> {
                 let mut fields = fields.try_into().map_err(|_| anyhow::Error::msg("unknown field"))?;
                 fields.merge_filter(&filter);
                 #load_checks
@@ -301,21 +310,19 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
                 for row in db.query(&db.prepare_cached(&sql).await?, &[#load_params]).await? {
                     results.push(fields.load_from_row(row, None)?);
                 }
-                Ok(results)
+                QueryStatsIterator::new(results)
             }
 
             /// Decompresses a group of data points.
-            pub fn decompress(self) -> anyhow::Result<Vec<#name>> {
-                let mut results = Vec::new();
+            fn decompress(self) -> anyhow::Result<impl Iterator<Item = #name>> {
+                let Self {
+                    #decompress_field_names
+                } = self;
                 #decompress_fields
-                let len = [#compressed_field_sizes].into_iter().max().unwrap_or(0);
-                for index in 0..len {
+                Ok(#decompress_fields_first.filter_map(move |#decompress_fields_first| {
                     let row = #name { #decompressed_fields };
-                    if self.filter.as_ref().map(|f| f.matches(&row)) != Some(false) {
-                        results.push(row);
-                    }
-                }
-                Ok(results)
+                    (filter.as_ref().map(|f| f.matches(&row)) != Some(false)).then(|| row)
+                }))
             }
 
             /// Writes the data to disk.
@@ -373,6 +380,38 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
                 Ok(())
             }
         }
+
+struct QueryStatsIterator {
+    groups: std::vec::IntoIter<#packed_name>,
+    buffer: std::collections::VecDeque<#name>,
+}
+impl QueryStatsIterator {
+    fn new(groups: Vec<#packed_name>) -> anyhow::Result<Self> {
+        Ok(Self { groups: groups.into_iter(), buffer: Default::default() })
+    }
+}
+impl Iterator for QueryStatsIterator {
+    type Item = anyhow::Result<#name>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(stat) = self.buffer.pop_front() {
+            return Some(Ok(stat));
+        }
+        while let Some(group) = self.groups.next() {
+            match group.decompress() {
+                Ok(stats) => {
+                    self.buffer.extend(stats);
+                    if let Some(stat) = self.buffer.pop_front() {
+                        return Some(Ok(stat));
+                    }
+                }
+                Err(e) => return Some(Err(e)),
+            }
+        }
+        None
+    }
+}
+
+
 
         #filter
         #fields


### PR DESCRIPTION
For #15, as an alternative to #41, that fully retains all `Result`s that can occur, which users have to handle:
- `let stat = stat?;` in for loops
- `collect::<Result<Vec<_>>>()?` to collect to a `Vec`

Collecting into a vec (the load case) is slightly slower while the reduce case is about the same. Both operations use more memory.

| Scenario | Load time | Load memory | Reduce time | Reduce memory |
| :--- | :--- | :--- | :--- | :--- |
| #41 | 330ms | 2312MB | 280ms | 31MB |
| this PR | 380ms | 2316MB | 270ms | 35MB |

I'm not a fan of this API for users, so it's worth considering the other option: a `FnMut(QueryStat)` closure argument so all errors are handled at the top level.