### PR TITLE
Benchmark serialization formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,12 +31,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,10 +161,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-fnv1a-hash"
-version = "1.1.0"
+name = "ciborium"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -324,155 +339,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "facet"
-version = "0.44.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa60b7d3d49d30f477f9490b7fc3ce42009b5b626b625b0356742884c493a11"
-dependencies = [
- "autocfg",
- "facet-core",
- "facet-macros",
-]
-
-[[package]]
-name = "facet-core"
-version = "0.44.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f9ee47507f15c18243a8cba3b2a85b71176173f0097e9164a54dd4e4e3e4ce"
-dependencies = [
- "autocfg",
- "const-fnv1a-hash",
- "iddqd",
- "impls",
-]
-
-[[package]]
-name = "facet-dessert"
-version = "0.44.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb18a3e7ee90139051f679390662ae158439c1564b73b482676b9a3862d13c0"
-dependencies = [
- "facet-core",
- "facet-reflect",
-]
-
-[[package]]
-name = "facet-format"
-version = "0.44.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87b44b7183a982f8c9889b7ec50bf8f1a38318a77069084436cc908bb1e5e96"
-dependencies = [
- "facet-core",
- "facet-dessert",
- "facet-path",
- "facet-reflect",
- "facet-solver",
-]
-
-[[package]]
-name = "facet-macro-parse"
-version = "0.44.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77becc35b3b3008e7b3ef23356954e46561177316aff0a92c73fc6ddb2a15a0"
-dependencies = [
- "facet-macro-types",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "facet-macro-types"
-version = "0.44.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e600db5983cdad99db3b34adfa20b546d80f21ab8feecd35d40bbbfbcf53b5c"
-dependencies = [
- "proc-macro2",
- "quote",
- "unsynn",
-]
-
-[[package]]
-name = "facet-macros"
-version = "0.44.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a7015e119aa043740dc8aee6b1b70e26b6616e1701b329496bf04990f44133"
-dependencies = [
- "facet-macros-impl",
-]
-
-[[package]]
-name = "facet-macros-impl"
-version = "0.44.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb5e6f6cc64210ab12aa625b014db78d34d6a3b63d1011382c141518a1e1f78"
-dependencies = [
- "facet-macro-parse",
- "facet-macro-types",
- "proc-macro2",
- "quote",
- "strsim",
- "unsynn",
-]
-
-[[package]]
-name = "facet-path"
-version = "0.44.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e7b83cb0de7c00d6e76f08d36b047d6cb9efc39e10744dbcf7a4a5a19c4903"
-dependencies = [
- "facet-core",
-]
-
-[[package]]
-name = "facet-postcard"
-version = "0.44.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7578186a9babca46fe08118e9a856b1ef158ae24b3a7a551926273ad1ad5e52a"
-dependencies = [
- "facet-core",
- "facet-format",
- "facet-path",
- "facet-reflect",
- "facet-value",
- "tracing",
-]
-
-[[package]]
-name = "facet-reflect"
-version = "0.44.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9cc255bd928399489868fdddec09e69073d622432cc2b52cfa3c3a5d811305c"
-dependencies = [
- "facet-core",
- "facet-path",
- "hashbrown 0.16.1",
- "smallvec 2.0.0-alpha.12",
-]
-
-[[package]]
-name = "facet-solver"
-version = "0.44.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d2427360875510d60267f4bb132f47aa4f5714896be9ca11c516f14542118d"
-dependencies = [
- "facet-core",
- "facet-reflect",
- "strsim",
-]
-
-[[package]]
-name = "facet-value"
-version = "0.44.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5edd5a4a2cb835ea6e0fc5a896a105505ddbde1bc1fa1e7e7f38bcc639eec5d8"
-dependencies = [
- "facet-core",
- "facet-format",
- "facet-reflect",
- "indexmap 2.13.1",
-]
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,12 +355,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures"
@@ -653,11 +513,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -705,29 +560,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "iddqd"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b215e67ed1d1a4b1702acd787c487d16e4c977c5dcbcc4587bdb5ea26b6ce06"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
- "hashbrown 0.16.1",
- "rustc-hash",
-]
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
-name = "impls"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a46645bbd70538861a90d0f26c31537cdf1e44aae99a794fb75a664b70951bc"
 
 [[package]]
 name = "indexmap"
@@ -876,12 +712,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mutants"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,7 +770,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.15.1",
+ "smallvec",
  "windows-targets",
 ]
 
@@ -963,11 +793,9 @@ dependencies = [
  "ahash",
  "anyhow",
  "chrono",
+ "ciborium",
  "deadpool-postgres",
  "dotenvy",
- "facet",
- "facet-postcard",
- "facet-value",
  "futures",
  "indexmap 2.13.1",
  "macrotest",
@@ -975,7 +803,9 @@ dependencies = [
  "peak_alloc",
  "proc-macro2",
  "quote",
+ "rmp-serde",
  "serde",
+ "serde_bytes",
  "serde_json",
  "serde_with",
  "serial_test",
@@ -1188,16 +1018,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustversion"
@@ -1258,6 +1101,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1401,12 +1254,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "smallvec"
-version = "2.0.0-alpha.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef784004ca8777809dcdad6ac37629f0a97caee4c685fcea805278d81dd8b857"
 
 [[package]]
 name = "socket2"
@@ -1680,17 +1527,6 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
-
-[[package]]
-name = "unsynn"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501a7adf1a4bd9951501e5c66621e972ef8874d787628b7f90e64f936ef7ec0a"
-dependencies = [
- "mutants",
- "proc-macro2",
- "rustc-hash",
-]
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +140,8 @@ version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -157,6 +165,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link",
 ]
+
+[[package]]
+name = "const-fnv1a-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
 
 [[package]]
 name = "core-foundation-sys"
@@ -310,6 +324,155 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "facet"
+version = "0.44.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa60b7d3d49d30f477f9490b7fc3ce42009b5b626b625b0356742884c493a11"
+dependencies = [
+ "autocfg",
+ "facet-core",
+ "facet-macros",
+]
+
+[[package]]
+name = "facet-core"
+version = "0.44.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f9ee47507f15c18243a8cba3b2a85b71176173f0097e9164a54dd4e4e3e4ce"
+dependencies = [
+ "autocfg",
+ "const-fnv1a-hash",
+ "iddqd",
+ "impls",
+]
+
+[[package]]
+name = "facet-dessert"
+version = "0.44.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fb18a3e7ee90139051f679390662ae158439c1564b73b482676b9a3862d13c0"
+dependencies = [
+ "facet-core",
+ "facet-reflect",
+]
+
+[[package]]
+name = "facet-format"
+version = "0.44.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87b44b7183a982f8c9889b7ec50bf8f1a38318a77069084436cc908bb1e5e96"
+dependencies = [
+ "facet-core",
+ "facet-dessert",
+ "facet-path",
+ "facet-reflect",
+ "facet-solver",
+]
+
+[[package]]
+name = "facet-macro-parse"
+version = "0.44.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77becc35b3b3008e7b3ef23356954e46561177316aff0a92c73fc6ddb2a15a0"
+dependencies = [
+ "facet-macro-types",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "facet-macro-types"
+version = "0.44.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e600db5983cdad99db3b34adfa20b546d80f21ab8feecd35d40bbbfbcf53b5c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unsynn",
+]
+
+[[package]]
+name = "facet-macros"
+version = "0.44.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a7015e119aa043740dc8aee6b1b70e26b6616e1701b329496bf04990f44133"
+dependencies = [
+ "facet-macros-impl",
+]
+
+[[package]]
+name = "facet-macros-impl"
+version = "0.44.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb5e6f6cc64210ab12aa625b014db78d34d6a3b63d1011382c141518a1e1f78"
+dependencies = [
+ "facet-macro-parse",
+ "facet-macro-types",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "unsynn",
+]
+
+[[package]]
+name = "facet-path"
+version = "0.44.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e7b83cb0de7c00d6e76f08d36b047d6cb9efc39e10744dbcf7a4a5a19c4903"
+dependencies = [
+ "facet-core",
+]
+
+[[package]]
+name = "facet-postcard"
+version = "0.44.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7578186a9babca46fe08118e9a856b1ef158ae24b3a7a551926273ad1ad5e52a"
+dependencies = [
+ "facet-core",
+ "facet-format",
+ "facet-path",
+ "facet-reflect",
+ "facet-value",
+ "tracing",
+]
+
+[[package]]
+name = "facet-reflect"
+version = "0.44.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9cc255bd928399489868fdddec09e69073d622432cc2b52cfa3c3a5d811305c"
+dependencies = [
+ "facet-core",
+ "facet-path",
+ "hashbrown 0.16.1",
+ "smallvec 2.0.0-alpha.12",
+]
+
+[[package]]
+name = "facet-solver"
+version = "0.44.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d2427360875510d60267f4bb132f47aa4f5714896be9ca11c516f14542118d"
+dependencies = [
+ "facet-core",
+ "facet-reflect",
+ "strsim",
+]
+
+[[package]]
+name = "facet-value"
+version = "0.44.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5edd5a4a2cb835ea6e0fc5a896a105505ddbde1bc1fa1e7e7f38bcc639eec5d8"
+dependencies = [
+ "facet-core",
+ "facet-format",
+ "facet-reflect",
+ "indexmap 2.13.1",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +489,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures"
@@ -481,9 +650,14 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -531,10 +705,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iddqd"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b215e67ed1d1a4b1702acd787c487d16e4c977c5dcbcc4587bdb5ea26b6ce06"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "hashbrown 0.16.1",
+ "rustc-hash",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "impls"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a46645bbd70538861a90d0f26c31537cdf1e44aae99a794fb75a664b70951bc"
 
 [[package]]
 name = "indexmap"
@@ -549,13 +742,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -574,6 +768,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -672,6 +876,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutants"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,7 +940,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec",
+ "smallvec 1.15.1",
  "windows-targets",
 ]
 
@@ -755,7 +965,11 @@ dependencies = [
  "chrono",
  "deadpool-postgres",
  "dotenvy",
+ "facet",
+ "facet-postcard",
+ "facet-value",
  "futures",
+ "indexmap 2.13.1",
  "macrotest",
  "pco",
  "peak_alloc",
@@ -768,6 +982,8 @@ dependencies = [
  "syn",
  "tokio",
  "tokio-postgres",
+ "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -813,6 +1029,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +1062,7 @@ dependencies = [
  "chrono",
  "fallible-iterator",
  "postgres-protocol",
+ "uuid",
 ]
 
 [[package]]
@@ -971,6 +1194,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,7 +1312,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.11.0",
+ "indexmap 2.13.1",
  "schemars 0.9.0",
  "schemars 1.2.0",
  "serde_core",
@@ -1172,6 +1401,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smallvec"
+version = "2.0.0-alpha.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef784004ca8777809dcdad6ac37629f0a97caee4c685fcea805278d81dd8b857"
 
 [[package]]
 name = "socket2"
@@ -1349,7 +1584,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
- "indexmap 2.11.0",
+ "indexmap 2.13.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1384,9 +1619,9 @@ checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -1395,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1406,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -1445,6 +1680,28 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unsynn"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501a7adf1a4bd9951501e5c66621e972ef8874d787628b7f90e64f936ef7ec0a"
+dependencies = [
+ "mutants",
+ "proc-macro2",
+ "rustc-hash",
+]
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "version_check"
@@ -1730,3 +1987,31 @@ name = "zmij"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,13 @@ zstd = "0.13"
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }
+ciborium = "0.2"
 dotenvy = "0.15"
-facet = "0.44"
-facet-postcard = "0.44"
-facet-value = "0.44"
 indexmap = { version = "2.13", features = ["serde"] }
 macrotest = "1.1"
 peak_alloc = "0.2"
+rmp-serde = "1.3"
+serde_bytes = "0.11"
 serial_test = "3.2"
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-uuid-1"] }
 tokio = { version = "1.43", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,18 +24,30 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 serde_with = "3.16"
 syn = "2.0"
-tokio-postgres = { version = "0.7", features = ["with-chrono-0_4"] }
+tokio-postgres = { version = "0.7" }
+uuid = "1.23"
+zstd = "0.13"
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }
 dotenvy = "0.15"
+facet = "0.44"
+facet-postcard = "0.44"
+facet-value = "0.44"
+indexmap = { version = "2.13", features = ["serde"] }
 macrotest = "1.1"
 peak_alloc = "0.2"
 serial_test = "3.2"
+tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-uuid-1"] }
 tokio = { version = "1.43", features = ["full"] }
+uuid = { version = "1.23", features = ["serde"] }
 
 [[bench]]
 name = "bucket_size"
+harness = false
+
+[[bench]]
+name = "comparison"
 harness = false
 
 [[bench]]
@@ -43,7 +55,7 @@ name = "float"
 harness = false
 
 [[bench]]
-name = "comparison"
+name = "serialization"
 harness = false
 
 [[bench]]

--- a/benches/README.md
+++ b/benches/README.md
@@ -55,6 +55,7 @@ Now with the optimized data model, this benchmark compares the performance of us
 This compares various serialization formats for several data types. Findings:
 
 - for numeric data, pco has >3x better compressed size and >5x faster deserialization, but serialization uses 2x more memory
+- for nested numeric data like `Vec<Vec<i64>>`, pco can achieve similar compression ratios by flattening the data and storing the length of each nested array in order to rebuild the nested structure later
 - serde deserialization is >5x faster than facet_postcard, and the other metrics are similar enough to not matter
 - maps are best stored as `BTreeMap` or `IndexMap` because `HashMap`'s random hasher hurts compression
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -52,12 +52,13 @@ Now with the optimized data model, this benchmark compares the performance of us
 
 ### `serialization.rs`
 
-This compares various serialization formats for several data types. Findings:
+This compares serialization formats for several data types. Observations:
 
-- for numeric data, pco has >3x better compressed size and >5x faster deserialization, but serialization uses 2x more memory
-- for nested numeric data like `Vec<Vec<i64>>`, pco can achieve similar compression ratios by flattening the data and storing the length of each nested array in order to rebuild the nested structure later
-- serde deserialization is >5x faster than facet_postcard, and the other metrics are similar enough to not matter
-- maps are best stored as `BTreeMap` or `IndexMap` because `HashMap`'s random hasher hurts compression
+- For numeric data, pco has >3x better compressed size and >5x faster deserialization, but serialization uses 2x more memory
+- For nested numeric data like `Vec<Vec<i64>>`, pco can achieve similar compression ratios by flattening the data and storing the length of each nested array in order to rebuild the nested structure later
+- CBOR is slightly better than JSON at compressed size and serialization time, and is much more efficient at encoding binary data
+- MessagePack improves on CBOR with faster deserialization, and with similar compressed size
+- Maps are best stored as `BTreeMap` or `IndexMap` because `HashMap`'s random key order hurts compression
 
 ### `chrono.rs`
 

--- a/benches/README.md
+++ b/benches/README.md
@@ -50,6 +50,14 @@ Now with the optimized data model, this benchmark compares the performance of us
 
 ## Others
 
+### `serialization.rs`
+
+This compares various serialization formats for several data types. Findings:
+
+- for numeric data, pco has >3x better compressed size and >5x faster deserialization, but serialization uses 2x more memory
+- serde deserialization is >5x faster than facet_postcard, and the other metrics are similar enough to not matter
+- maps are best stored as `BTreeMap` or `IndexMap` because `HashMap`'s random hasher hurts compression
+
 ### `chrono.rs`
 
 The standard library `SystemTime` is being used depsite [chrono's](https://crates.io/crates/chrono) more feature-complete API because adding durations to a timestamp (in `decompress`) is noticeably slower when using chrono.

--- a/benches/serialization.rs
+++ b/benches/serialization.rs
@@ -1,0 +1,290 @@
+use anyhow::Result;
+use indexmap::IndexMap;
+use peak_alloc::PeakAlloc;
+use std::collections::{BTreeMap, HashMap};
+use std::hint::black_box;
+use std::time::Instant;
+
+#[global_allocator]
+static PEAK_ALLOC: PeakAlloc = PeakAlloc;
+
+fn main() {
+    println!();
+    bench_pco(numbers(), "i64");
+    bench_serde(numbers(), "i64");
+    bench_facet(numbers(), "i64");
+    println!();
+    bench_serde(strings(), "String");
+    bench_facet(strings(), "String");
+    println!();
+    bench_serde(serde_values(), "serde_json::Value");
+    bench_facet(facet_values(), "facet_value::Value");
+    println!();
+    bench_serde(hashmap(), "HashMap<String, String>");
+    bench_facet(hashmap(), "HashMap<String, String>");
+    println!();
+    bench_serde(btreemap(), "BTreeMap<String, String>");
+    bench_facet(btreemap(), "BTreeMap<String, String>");
+    println!();
+    bench_serde(indexmap(), "IndexMap<String, String>");
+    println!("== facet_postcard Vec<IndexMap<String, String>>");
+    println!("!! skipped because IndexMap doesn't support Facet");
+    println!();
+    bench_serde(structs(), "Struct");
+    bench_facet(structs(), "Struct");
+    println!();
+}
+
+fn bench_pco<T>(values: Vec<T>, r#type: &str)
+where
+    T: pco::data_types::Number,
+{
+    println!("== pco Vec<{type}>");
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let bytes = pco::standalone::simpler_compress(&values, pco::DEFAULT_COMPRESSION_LEVEL).unwrap();
+    println!("serialized to {:.0?} bytes after {:.1?} using {:.0?}KB peak memory", bytes.len(), start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    for v in pco::standalone::simple_decompress::<T>(&bytes).unwrap() {
+        black_box(v);
+    }
+    println!("deserialized and discarded after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let result: Vec<T> = pco::standalone::simple_decompress(&bytes).unwrap();
+    black_box(result);
+    println!("deserialized and retained after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+}
+
+fn bench_serde<T>(values: Vec<T>, r#type: &str)
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + 'static,
+{
+    println!("== serde Vec<{type}>");
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let bytes = serde_compress(values).unwrap();
+    println!("serialized to {:.0?} bytes after {:.1?} using {:.0?}KB peak memory", bytes.len(), start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    for v in serde_decompress::<T>(&bytes) {
+        black_box(v.unwrap());
+    }
+    println!("deserialized and discarded after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let result: Vec<T> = serde_decompress::<T>(&bytes).collect::<Result<_>>().unwrap();
+    black_box(result);
+    println!("deserialized and retained after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+}
+
+fn bench_facet<T>(values: Vec<T>, r#type: &str)
+where
+    T: for<'a> facet::Facet<'a>,
+{
+    println!("== facet_postcard Vec<{type}>");
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let bytes = facet_compress(values).unwrap();
+    println!("serialized to {:.0?} bytes after {:.1?} using {:.0?}KB peak memory", bytes.len(), start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    for v in facet_decompress::<T>(&bytes) {
+        black_box(v.unwrap());
+    }
+    println!("deserialized and discarded after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let result: Vec<T> = facet_decompress::<T>(&bytes).collect::<Result<_>>().unwrap();
+    black_box(result);
+    println!("deserialized and retained after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+}
+
+fn strings() -> Vec<String> {
+    let mut values = Vec::new();
+    for i in 0..100_000u32 {
+        let id = i.pow(2);
+        values.extend([format!("Key A {i}"), format!("Value A {i}"), format!("Key B {id}"), format!("Value B {id}")]);
+    }
+    values
+}
+
+fn numbers() -> Vec<u64> {
+    let mut values = Vec::new();
+    for i in 0..100_000u64 {
+        values.extend([i, i * 2, i.pow(2)]);
+    }
+    values
+}
+
+fn serde_values() -> Vec<serde_json::Value> {
+    let mut values = Vec::new();
+    for i in 0..100_000u32 {
+        let id = i.pow(2);
+        values.push(serde_json::json!({
+            format!("Key A {i}"): format!("Value A {i}"),
+            format!("Key B {id}"): format!("Value B {id}"),
+        }));
+    }
+    values
+}
+
+fn facet_values() -> Vec<facet_value::Value> {
+    let mut values = Vec::new();
+    for i in 0..100_000u32 {
+        let id = i.pow(2);
+        let (keya, valuea) = (format!("Key A {i}"), format!("Value A {i}"));
+        let (keyb, valueb) = (format!("Key B {id}"), format!("Value B {id}"));
+        values.push(facet_value::value!({ keya: valuea, keyb: valueb }));
+    }
+    values
+}
+
+fn hashmap() -> Vec<HashMap<String, String>> {
+    let mut values = Vec::new();
+    for i in 0..100_000u32 {
+        let id = i.pow(2);
+        values.push(HashMap::from([(format!("Key A {i}"), format!("Value A {i}")), (format!("Key B {id}"), format!("Value B {id}"))]));
+    }
+    values
+}
+
+fn btreemap() -> Vec<BTreeMap<String, String>> {
+    let mut values = Vec::new();
+    for i in 0..100_000u32 {
+        let id = i.pow(2);
+        values.push(BTreeMap::from([(format!("Key A {i}"), format!("Value A {i}")), (format!("Key B {id}"), format!("Value B {id}"))]));
+    }
+    values
+}
+
+fn indexmap() -> Vec<IndexMap<String, String>> {
+    let mut values = Vec::new();
+    for i in 0..100_000u32 {
+        let id = i.pow(2);
+        values.push(IndexMap::from([(format!("Key A {i}"), format!("Value A {i}")), (format!("Key B {id}"), format!("Value B {id}"))]));
+    }
+    values
+}
+
+#[derive(serde::Serialize, serde::Deserialize, facet::Facet)]
+struct Struct {
+    a: u32,
+    b: u32,
+    c: String,
+    d: String,
+}
+
+fn structs() -> Vec<Struct> {
+    let mut values = Vec::new();
+    for i in 0..100_000u32 {
+        let id = i.pow(2);
+        values.push(Struct { a: i, b: id, c: format!("String {i}"), d: format!("Other {id}") });
+    }
+    values
+}
+
+//
+// Below is custom compression + serialization logic for serde and facet_postcard.
+// Since string-like data can be very large, we use a streaming approach so during decompression,
+// each row can be individually hydrated into memory, significantly reducing memory usage
+// when many rows are immediately filtered out.
+//
+
+fn serde_compress<T>(items: Vec<T>) -> anyhow::Result<Vec<u8>>
+where
+    T: serde::Serialize,
+{
+    use std::io::Write;
+    let mut output = Vec::new();
+    let mut encoder = zstd::stream::write::Encoder::new(&mut output, 3)?;
+    for item in items {
+        serde_json::to_writer(&mut encoder, &item)?;
+        encoder.write_all(b"\n")?; // The "L" in JSONL
+    }
+    encoder.finish()?;
+    Ok(output)
+}
+
+fn serde_decompress<T>(input: &[u8]) -> impl Iterator<Item = anyhow::Result<T>> + '_
+where
+    T: for<'de> serde::Deserialize<'de> + 'static,
+{
+    let decoder = match zstd::stream::read::Decoder::new(input) {
+        Ok(d) => d,
+        Err(e) => return Box::new(std::iter::once(Err(e.into()))) as Box<dyn Iterator<Item = _>>,
+    };
+    let buffered = std::io::BufReader::with_capacity(128 * 1024, decoder);
+    let json_iter = serde_json::Deserializer::from_reader(buffered).into_iter::<T>();
+    Box::new(json_iter.map(|res| res.map_err(anyhow::Error::from)))
+}
+
+fn facet_compress<T, I>(items: I) -> anyhow::Result<Vec<u8>>
+where
+    T: for<'a> facet::Facet<'a>,
+    I: IntoIterator<Item = T>,
+{
+    use std::io::Write;
+    let mut output = Vec::new();
+    let mut encoder = zstd::stream::write::Encoder::new(&mut output, 3)?;
+    for item in items {
+        let bytes = facet_postcard::to_vec(&item)?;
+        // Encode and write the length prefix
+        let mut len = bytes.len();
+        loop {
+            let byte = (len & 0x7F) as u8;
+            len >>= 7;
+            if len > 0 {
+                // Set continuation bit
+                encoder.write_all(&[byte | 0x80])?;
+            } else {
+                encoder.write_all(&[byte])?;
+                break;
+            }
+        }
+        // Write the actual data
+        encoder.write_all(&bytes)?;
+    }
+    encoder.finish()?;
+    Ok(output)
+}
+
+fn facet_decompress<'a, T>(input: &'a [u8]) -> impl Iterator<Item = anyhow::Result<T>> + 'a
+where
+    T: facet::Facet<'static> + 'a,
+{
+    use std::io::Read;
+    let decoder = zstd::stream::read::Decoder::new(input).unwrap();
+    let mut reader = std::io::BufReader::with_capacity(128 * 1024, decoder);
+    let mut buffer = Vec::new();
+    std::iter::from_fn(move || {
+        // Read length prefix
+        let mut len: usize = 0;
+        let mut shift = 0;
+        loop {
+            let mut b = [0u8; 1];
+            if let Err(_) = reader.read_exact(&mut b) {
+                return None; // EOF
+            }
+            let byte = b[0];
+            len |= ((byte & 0x7F) as usize) << shift;
+            if (byte & 0x80) == 0 {
+                break;
+            }
+            shift += 7;
+            if shift > 63 {
+                return Some(Err(anyhow::anyhow!("Varint overflow")));
+            }
+        }
+        // Read the exact number of bytes from the length prefix
+        buffer.resize(len, 0);
+        if let Err(e) = reader.read_exact(&mut buffer) {
+            return Some(Err(e.into()));
+        }
+        match facet_postcard::from_slice::<T>(&buffer) {
+            Ok(item) => Some(Ok(item)),
+            Err(e) => Some(Err(anyhow::anyhow!("Postcard error: {:?}", e))),
+        }
+    })
+}

--- a/benches/serialization.rs
+++ b/benches/serialization.rs
@@ -12,28 +12,39 @@ fn main() {
     println!();
     bench_pco(numbers(), "i64");
     bench_serde(numbers(), "i64");
-    bench_facet(numbers(), "i64");
+    bench_msgpack(numbers(), "i64");
+    bench_cbor(numbers(), "i64");
     println!();
-    bench_flat_pco(numbers_nested(), "Vec<u64> + Vec<i64> (flattened)");
+    bench_flat_serde(numbers_nested(), "Vec<u64> + Vec<i64> (flattened)");
+    bench_flat_msgpack(numbers_nested(), "Vec<u64> + Vec<i64> (flattened)");
+    bench_flat_cbor(numbers_nested(), "Vec<u64> + Vec<i64> (flattened)");
     bench_serde(numbers_nested(), "Vec<i64>");
-    bench_facet(numbers_nested(), "Vec<i64>");
+    bench_msgpack(numbers_nested(), "Vec<i64>");
+    bench_cbor(numbers_nested(), "Vec<i64>");
     println!();
     bench_serde(strings(), "String");
-    bench_facet(strings(), "String");
+    bench_msgpack(strings(), "String");
+    bench_cbor(strings(), "String");
     println!();
     bench_serde(serde_values(), "serde_json::Value");
-    bench_facet(facet_values(), "facet_value::Value");
+    bench_msgpack(serde_values(), "serde_json::Value");
+    bench_cbor(serde_values(), "serde_json::Value");
     println!();
     bench_serde(hashmap(), "HashMap<String, String>");
-    bench_facet(hashmap(), "HashMap<String, String>");
+    bench_msgpack(hashmap(), "HashMap<String, String>");
+    bench_cbor(hashmap(), "HashMap<String, String>");
     println!();
     bench_serde(btreemap(), "BTreeMap<String, String>");
-    bench_facet(btreemap(), "BTreeMap<String, String>");
+    bench_msgpack(btreemap(), "BTreeMap<String, String>");
+    bench_cbor(btreemap(), "BTreeMap<String, String>");
     println!();
     bench_serde(indexmap(), "IndexMap<String, String>");
+    bench_msgpack(indexmap(), "IndexMap<String, String>");
+    bench_cbor(indexmap(), "IndexMap<String, String>");
     println!();
     bench_serde(structs(), "Struct");
-    bench_facet(structs(), "Struct");
+    bench_msgpack(structs(), "Struct");
+    bench_cbor(structs(), "Struct");
     println!();
 }
 
@@ -53,7 +64,7 @@ where
     println!("deserialized and retained after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
 }
 
-fn bench_flat_pco<T>(nested_values: Vec<Vec<T>>, r#type: &str)
+fn bench_flat_serde<T>(nested_values: Vec<Vec<T>>, r#type: &str)
 where
     T: pco::data_types::Number,
 {
@@ -63,16 +74,17 @@ where
         lengths.push(value.len() as u64);
         values.extend(value);
     }
-    println!("== pco {type}");
+    println!("== pco + serde {type}");
     PEAK_ALLOC.reset_peak_usage();
     let start = Instant::now();
     let length_bytes = pco::standalone::simpler_compress(&lengths, pco::DEFAULT_COMPRESSION_LEVEL).unwrap();
     let value_bytes = pco::standalone::simpler_compress(&values, pco::DEFAULT_COMPRESSION_LEVEL).unwrap();
-    let bytes = encode_nested_vec(length_bytes, value_bytes);
+    let (length_bytes, value_bytes) = (serde_bytes::Bytes::new(&length_bytes), serde_bytes::Bytes::new(&value_bytes));
+    let bytes = serde_json::to_vec(&(length_bytes, value_bytes)).unwrap();
     println!("serialized to {:.0?} bytes after {:.1?} using {:.0?}KB peak memory", bytes.len(), start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
     PEAK_ALLOC.reset_peak_usage();
     let start = Instant::now();
-    let (length_bytes, value_bytes) = decode_nested_vec(&bytes).unwrap();
+    let (length_bytes, value_bytes) = serde_json::from_slice::<(Vec<u8>, Vec<u8>)>(&bytes).unwrap();
     let lengths = pco::standalone::simple_decompress::<u64>(&length_bytes).unwrap();
     let values = pco::standalone::simple_decompress::<T>(&value_bytes).unwrap();
     let mut values = values.into_iter();
@@ -84,21 +96,69 @@ where
     println!("deserialized and retained after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
 }
 
-fn encode_nested_vec(v1: Vec<u8>, v2: Vec<u8>) -> Vec<u8> {
-    let mut out = Vec::with_capacity(8 + v1.len() + 8 + v2.len());
-    out.extend_from_slice(&(v1.len() as u64).to_le_bytes());
-    out.extend(v1);
-    out.extend_from_slice(&(v2.len() as u64).to_le_bytes());
-    out.extend(v2);
-    out
+fn bench_flat_msgpack<T>(nested_values: Vec<Vec<T>>, r#type: &str)
+where
+    T: pco::data_types::Number,
+{
+    let mut lengths = Vec::new();
+    let mut values = Vec::new();
+    for value in nested_values {
+        lengths.push(value.len() as u64);
+        values.extend(value);
+    }
+    println!("== pco + msgpack {type}");
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let length_bytes = pco::standalone::simpler_compress(&lengths, pco::DEFAULT_COMPRESSION_LEVEL).unwrap();
+    let value_bytes = pco::standalone::simpler_compress(&values, pco::DEFAULT_COMPRESSION_LEVEL).unwrap();
+    let (length_bytes, value_bytes) = (serde_bytes::Bytes::new(&length_bytes), serde_bytes::Bytes::new(&value_bytes));
+    let bytes = rmp_serde::to_vec(&(length_bytes, value_bytes)).unwrap();
+    println!("serialized to {:.0?} bytes after {:.1?} using {:.0?}KB peak memory", bytes.len(), start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let (length_bytes, value_bytes) = rmp_serde::from_slice::<(Vec<u8>, Vec<u8>)>(&bytes).unwrap();
+    let lengths = pco::standalone::simple_decompress::<u64>(&length_bytes).unwrap();
+    let values = pco::standalone::simple_decompress::<T>(&value_bytes).unwrap();
+    let mut values = values.into_iter();
+    let mut combined = Vec::with_capacity(lengths.len());
+    for length in lengths {
+        combined.push(values.by_ref().take(length as usize).collect::<Vec<T>>());
+    }
+    black_box(combined);
+    println!("deserialized and retained after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
 }
 
-fn decode_nested_vec(data: &[u8]) -> Result<(&[u8], &[u8]), &'static str> {
-    let len1 = u64::from_le_bytes(data[0..8].try_into().unwrap()) as usize;
-    let vec1 = &data[8..8 + len1];
-    let len2 = u64::from_le_bytes(data[8 + len1..16 + len1].try_into().unwrap()) as usize;
-    let vec2 = &data[16 + len1..16 + len1 + len2];
-    Ok((vec1, vec2))
+fn bench_flat_cbor<T>(nested_values: Vec<Vec<T>>, r#type: &str)
+where
+    T: pco::data_types::Number,
+{
+    let mut lengths = Vec::new();
+    let mut values = Vec::new();
+    for value in nested_values {
+        lengths.push(value.len() as u64);
+        values.extend(value);
+    }
+    println!("== pco + cbor {type}");
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let length_bytes = pco::standalone::simpler_compress(&lengths, pco::DEFAULT_COMPRESSION_LEVEL).unwrap();
+    let value_bytes = pco::standalone::simpler_compress(&values, pco::DEFAULT_COMPRESSION_LEVEL).unwrap();
+    let (length_bytes, value_bytes) = (serde_bytes::Bytes::new(&length_bytes), serde_bytes::Bytes::new(&value_bytes));
+    let mut bytes = Vec::new();
+    ciborium::into_writer(&(length_bytes, value_bytes), &mut bytes).unwrap();
+    println!("serialized to {:.0?} bytes after {:.1?} using {:.0?}KB peak memory", bytes.len(), start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let (length_bytes, value_bytes): (Vec<u8>, Vec<u8>) = ciborium::from_reader(&bytes[..]).unwrap();
+    let lengths = pco::standalone::simple_decompress::<u64>(&length_bytes).unwrap();
+    let values = pco::standalone::simple_decompress::<T>(&value_bytes).unwrap();
+    let mut values = values.into_iter();
+    let mut combined = Vec::with_capacity(lengths.len());
+    for length in lengths {
+        combined.push(values.by_ref().take(length as usize).collect::<Vec<T>>());
+    }
+    black_box(combined);
+    println!("deserialized and retained after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
 }
 
 fn bench_serde<T>(values: Vec<T>, r#type: &str)
@@ -123,24 +183,46 @@ where
     println!("deserialized and retained after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
 }
 
-fn bench_facet<T>(values: Vec<T>, r#type: &str)
+fn bench_msgpack<T>(values: Vec<T>, r#type: &str)
 where
-    T: for<'a> facet::Facet<'a>,
+    T: serde::Serialize + serde::de::DeserializeOwned + 'static,
 {
-    println!("== facet_postcard Vec<{type}>");
+    println!("== msgpack Vec<{type}>");
     PEAK_ALLOC.reset_peak_usage();
     let start = Instant::now();
-    let bytes = facet_compress(values).unwrap();
+    let bytes = msgpack_compress(values).unwrap();
     println!("serialized to {:.0?} bytes after {:.1?} using {:.0?}KB peak memory", bytes.len(), start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
     PEAK_ALLOC.reset_peak_usage();
     let start = Instant::now();
-    for v in facet_decompress::<T>(&bytes) {
+    for v in msgpack_decompress::<T>(&bytes) {
         black_box(v.unwrap());
     }
     println!("deserialized and discarded after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
     PEAK_ALLOC.reset_peak_usage();
     let start = Instant::now();
-    let result: Vec<T> = facet_decompress::<T>(&bytes).collect::<Result<_>>().unwrap();
+    let result: Vec<T> = msgpack_decompress::<T>(&bytes).collect::<Result<_>>().unwrap();
+    black_box(result);
+    println!("deserialized and retained after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+}
+
+fn bench_cbor<T>(values: Vec<T>, r#type: &str)
+where
+    T: serde::Serialize + serde::de::DeserializeOwned + 'static,
+{
+    println!("== cbor Vec<{type}>");
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let bytes = cbor_compress(values).unwrap();
+    println!("serialized to {:.0?} bytes after {:.1?} using {:.0?}KB peak memory", bytes.len(), start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    for v in cbor_decompress::<T>(&bytes) {
+        black_box(v.unwrap());
+    }
+    println!("deserialized and discarded after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let result: Vec<T> = cbor_decompress::<T>(&bytes).collect::<Result<_>>().unwrap();
     black_box(result);
     println!("deserialized and retained after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
 }
@@ -182,17 +264,6 @@ fn serde_values() -> Vec<serde_json::Value> {
     values
 }
 
-fn facet_values() -> Vec<facet_value::Value> {
-    let mut values = Vec::new();
-    for i in 0..100_000u32 {
-        let id = i.pow(2);
-        let (keya, valuea) = (format!("Key A {i}"), format!("Value A {i}"));
-        let (keyb, valueb) = (format!("Key B {id}"), format!("Value B {id}"));
-        values.push(facet_value::value!({ keya: valuea, keyb: valueb }));
-    }
-    values
-}
-
 fn hashmap() -> Vec<HashMap<String, String>> {
     let mut values = Vec::new();
     for i in 0..100_000u32 {
@@ -220,7 +291,7 @@ fn indexmap() -> Vec<IndexMap<String, String>> {
     values
 }
 
-#[derive(serde::Serialize, serde::Deserialize, facet::Facet)]
+#[derive(serde::Serialize, serde::Deserialize)]
 struct Struct {
     a: u32,
     b: u32,
@@ -238,7 +309,6 @@ fn structs() -> Vec<Struct> {
 }
 
 //
-// Below is custom compression + serialization logic for serde and facet_postcard.
 // Since string-like data can be very large, we use a streaming approach so during decompression,
 // each row can be individually hydrated into memory, significantly reducing memory usage
 // when many rows are immediately filtered out.
@@ -272,71 +342,62 @@ where
     Box::new(json_iter.map(|res| res.map_err(anyhow::Error::from)))
 }
 
-fn facet_compress<T, I>(items: I) -> anyhow::Result<Vec<u8>>
+fn msgpack_compress<T>(items: Vec<T>) -> anyhow::Result<Vec<u8>>
 where
-    T: for<'a> facet::Facet<'a>,
-    I: IntoIterator<Item = T>,
+    T: serde::Serialize,
 {
-    use std::io::Write;
     let mut output = Vec::new();
     let mut encoder = zstd::stream::write::Encoder::new(&mut output, 3)?;
     for item in items {
-        let bytes = facet_postcard::to_vec(&item)?;
-        // Encode and write the length prefix
-        let mut len = bytes.len();
-        loop {
-            let byte = (len & 0x7F) as u8;
-            len >>= 7;
-            if len > 0 {
-                // Set continuation bit
-                encoder.write_all(&[byte | 0x80])?;
-            } else {
-                encoder.write_all(&[byte])?;
-                break;
-            }
-        }
-        // Write the actual data
-        encoder.write_all(&bytes)?;
+        // Serialize directly into the zstd encoder
+        rmp_serde::encode::write(&mut encoder, &item)?;
     }
     encoder.finish()?;
     Ok(output)
 }
 
-fn facet_decompress<'a, T>(input: &'a [u8]) -> impl Iterator<Item = anyhow::Result<T>> + 'a
+fn msgpack_decompress<T>(input: &[u8]) -> impl Iterator<Item = anyhow::Result<T>> + '_
 where
-    T: facet::Facet<'static> + 'a,
+    T: for<'de> serde::Deserialize<'de> + 'static,
 {
-    use std::io::Read;
-    let decoder = zstd::stream::read::Decoder::new(input).unwrap();
-    let mut reader = std::io::BufReader::with_capacity(128 * 1024, decoder);
-    let mut buffer = Vec::new();
-    std::iter::from_fn(move || {
-        // Read length prefix
-        let mut len: usize = 0;
-        let mut shift = 0;
-        loop {
-            let mut b = [0u8; 1];
-            if let Err(_) = reader.read_exact(&mut b) {
-                return None; // EOF
-            }
-            let byte = b[0];
-            len |= ((byte & 0x7F) as usize) << shift;
-            if (byte & 0x80) == 0 {
-                break;
-            }
-            shift += 7;
-            if shift > 63 {
-                return Some(Err(anyhow::anyhow!("Varint overflow")));
-            }
-        }
-        // Read the exact number of bytes from the length prefix
-        buffer.resize(len, 0);
-        if let Err(e) = reader.read_exact(&mut buffer) {
-            return Some(Err(e.into()));
-        }
-        match facet_postcard::from_slice::<T>(&buffer) {
-            Ok(item) => Some(Ok(item)),
-            Err(e) => Some(Err(anyhow::anyhow!("Postcard error: {:?}", e))),
-        }
-    })
+    let decoder = match zstd::stream::read::Decoder::new(input) {
+        Ok(d) => d,
+        Err(e) => return Box::new(std::iter::once(Err(e.into()))) as Box<dyn Iterator<Item = _>>,
+    };
+    let buffered = std::io::BufReader::with_capacity(128 * 1024, decoder);
+    let mut de = rmp_serde::decode::Deserializer::new(buffered);
+    Box::new(std::iter::from_fn(move || match serde::Deserialize::deserialize(&mut de) {
+        Ok(item) => Some(Ok(item)),
+        Err(rmp_serde::decode::Error::InvalidMarkerRead(ref e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => None,
+        Err(e) => Some(Err(anyhow::anyhow!(e))),
+    }))
+}
+
+fn cbor_compress<T>(items: Vec<T>) -> anyhow::Result<Vec<u8>>
+where
+    T: serde::Serialize,
+{
+    let mut output = Vec::new();
+    let mut encoder = zstd::stream::write::Encoder::new(&mut output, 3)?;
+    for item in items {
+        ciborium::into_writer(&item, &mut encoder)?;
+    }
+    encoder.finish()?;
+    Ok(output)
+}
+
+fn cbor_decompress<T>(input: &[u8]) -> impl Iterator<Item = anyhow::Result<T>> + '_
+where
+    T: for<'de> serde::Deserialize<'de> + 'static,
+{
+    let decoder = match zstd::stream::read::Decoder::new(input) {
+        Ok(d) => d,
+        Err(e) => return Box::new(std::iter::once(Err(e.into()))) as Box<dyn Iterator<Item = _>>,
+    };
+    let mut buffered = std::io::BufReader::with_capacity(128 * 1024, decoder);
+    Box::new(std::iter::from_fn(move || match ciborium::from_reader::<T, _>(&mut buffered) {
+        Ok(item) => Some(Ok(item)),
+        Err(ciborium::de::Error::Io(ref e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => None,
+        Err(e) => Some(Err(anyhow::anyhow!(e))),
+    }))
 }

--- a/benches/serialization.rs
+++ b/benches/serialization.rs
@@ -14,6 +14,10 @@ fn main() {
     bench_serde(numbers(), "i64");
     bench_facet(numbers(), "i64");
     println!();
+    bench_flat_pco(numbers_nested(), "Vec<u64> + Vec<i64> (flattened)");
+    bench_serde(numbers_nested(), "Vec<i64>");
+    bench_facet(numbers_nested(), "Vec<i64>");
+    println!();
     bench_serde(strings(), "String");
     bench_facet(strings(), "String");
     println!();
@@ -27,8 +31,6 @@ fn main() {
     bench_facet(btreemap(), "BTreeMap<String, String>");
     println!();
     bench_serde(indexmap(), "IndexMap<String, String>");
-    println!("== facet_postcard Vec<IndexMap<String, String>>");
-    println!("!! skipped because IndexMap doesn't support Facet");
     println!();
     bench_serde(structs(), "Struct");
     bench_facet(structs(), "Struct");
@@ -46,15 +48,57 @@ where
     println!("serialized to {:.0?} bytes after {:.1?} using {:.0?}KB peak memory", bytes.len(), start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
     PEAK_ALLOC.reset_peak_usage();
     let start = Instant::now();
-    for v in pco::standalone::simple_decompress::<T>(&bytes).unwrap() {
-        black_box(v);
-    }
-    println!("deserialized and discarded after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
-    PEAK_ALLOC.reset_peak_usage();
-    let start = Instant::now();
     let result: Vec<T> = pco::standalone::simple_decompress(&bytes).unwrap();
     black_box(result);
     println!("deserialized and retained after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+}
+
+fn bench_flat_pco<T>(nested_values: Vec<Vec<T>>, r#type: &str)
+where
+    T: pco::data_types::Number,
+{
+    let mut lengths = Vec::new();
+    let mut values = Vec::new();
+    for value in nested_values {
+        lengths.push(value.len() as u64);
+        values.extend(value);
+    }
+    println!("== pco {type}");
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let length_bytes = pco::standalone::simpler_compress(&lengths, pco::DEFAULT_COMPRESSION_LEVEL).unwrap();
+    let value_bytes = pco::standalone::simpler_compress(&values, pco::DEFAULT_COMPRESSION_LEVEL).unwrap();
+    let bytes = encode_nested_vec(length_bytes, value_bytes);
+    println!("serialized to {:.0?} bytes after {:.1?} using {:.0?}KB peak memory", bytes.len(), start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+    PEAK_ALLOC.reset_peak_usage();
+    let start = Instant::now();
+    let (length_bytes, value_bytes) = decode_nested_vec(&bytes).unwrap();
+    let lengths = pco::standalone::simple_decompress::<u64>(&length_bytes).unwrap();
+    let values = pco::standalone::simple_decompress::<T>(&value_bytes).unwrap();
+    let mut values = values.into_iter();
+    let mut combined = Vec::with_capacity(lengths.len());
+    for length in lengths {
+        combined.push(values.by_ref().take(length as usize).collect::<Vec<T>>());
+    }
+    black_box(combined);
+    println!("deserialized and retained after {:.1?} using {:.0?}KB peak memory", start.elapsed(), PEAK_ALLOC.peak_usage_as_kb());
+}
+
+fn encode_nested_vec(v1: Vec<u8>, v2: Vec<u8>) -> Vec<u8> {
+    let mut out = Vec::with_capacity(8 + v1.len() + 8 + v2.len());
+    out.extend_from_slice(&(v1.len() as u64).to_le_bytes());
+    out.extend(v1);
+    out.extend_from_slice(&(v2.len() as u64).to_le_bytes());
+    out.extend(v2);
+    out
+}
+
+fn decode_nested_vec(data: &[u8]) -> Result<(&[u8], &[u8]), &'static str> {
+    let len1 = u64::from_le_bytes(data[0..8].try_into().unwrap()) as usize;
+    let vec1 = &data[8..8 + len1];
+    let len2 = u64::from_le_bytes(data[8 + len1..16 + len1].try_into().unwrap()) as usize;
+    let vec2 = &data[16 + len1..16 + len1 + len2];
+    Ok((vec1, vec2))
 }
 
 fn bench_serde<T>(values: Vec<T>, r#type: &str)
@@ -114,6 +158,14 @@ fn numbers() -> Vec<u64> {
     let mut values = Vec::new();
     for i in 0..100_000u64 {
         values.extend([i, i * 2, i.pow(2)]);
+    }
+    values
+}
+
+fn numbers_nested() -> Vec<Vec<u64>> {
+    let mut values = Vec::new();
+    for i in 0..100_000u64 {
+        values.push(vec![i, i * 2, i.pow(2)]);
     }
     values
 }


### PR DESCRIPTION
I was planning on using facet_postcard for #9, but this benchmark shows that we should stick with serde instead.

Benchmark findings:
- For numeric data, pco has >3x better compressed size and >5x faster deserialization, but serialization uses 2x more memory
- For nested numeric data like `Vec<Vec<i64>>`, pco can achieve similar compression ratios by flattening the data and storing the length of each nested array in order to rebuild the nested structure later
- Serde deserialization is >5x faster than facet_postcard (since removed from the benchmark)
- CBOR is slightly better than JSON at compressed size and serialization time, and is much more efficient at encoding binary data
- MessagePack improves on CBOR with faster deserialization, and with similar compressed size
- Maps are best stored as `BTreeMap` or `IndexMap` because `HashMap`'s random key order hurts compression

<details><summary>Updated <code>cargo bench --bench serialization</code> output including MessagePack and CBOR</summary>

```rs
== pco Vec<i64>
serialized to 273787 bytes after 8.3ms using 11465KB peak memory
deserialized and retained after 969.9µs using 7310KB peak memory
== serde Vec<i64>
serialized to 777214 bytes after 13.7ms using 5666KB peak memory
deserialized and discarded after 6.4ms using 1282KB peak memory
deserialized and retained after 6.4ms using 7426KB peak memory
== msgpack Vec<i64>
serialized to 847853 bytes after 8.2ms using 5666KB peak memory
deserialized and discarded after 2.1ms using 1282KB peak memory
deserialized and retained after 2.1ms using 7426KB peak memory
== cbor Vec<i64>
serialized to 858808 bytes after 8.6ms using 5666KB peak memory
deserialized and discarded after 14.9ms using 1282KB peak memory
deserialized and retained after 14.8ms using 7426KB peak memory

== pco + serde Vec<u64> + Vec<i64> (flattened)
serialized to 968617 bytes after 8.7ms using 12489KB peak memory
deserialized and retained after 4.4ms using 14793KB peak memory
== pco + msgpack Vec<u64> + Vec<i64> (flattened)
serialized to 273822 bytes after 7.7ms using 12489KB peak memory
deserialized and retained after 2.6ms using 13792KB peak memory
== pco + cbor Vec<u64> + Vec<i64> (flattened)
serialized to 273822 bytes after 7.9ms using 12489KB peak memory
deserialized and retained after 2.5ms using 13792KB peak memory
== serde Vec<Vec<i64>>
serialized to 790233 bytes after 16.3ms using 5449KB peak memory
deserialized and discarded after 7.8ms using 1282KB peak memory
deserialized and retained after 8.1ms using 7938KB peak memory
== msgpack Vec<Vec<i64>>
serialized to 899317 bytes after 10.0ms using 5777KB peak memory
deserialized and discarded after 3.2ms using 1282KB peak memory
deserialized and retained after 3.4ms using 7426KB peak memory
== cbor Vec<Vec<i64>>
serialized to 862179 bytes after 10.3ms using 5777KB peak memory
deserialized and discarded after 8.5ms using 1282KB peak memory
deserialized and retained after 9.4ms using 7426KB peak memory

== serde Vec<String>
serialized to 1043406 bytes after 32.0ms using 20336KB peak memory
deserialized and discarded after 19.1ms using 1461KB peak memory
deserialized and retained after 19.5ms using 23493KB peak memory
== msgpack Vec<String>
serialized to 982138 bytes after 21.6ms using 20336KB peak memory
deserialized and discarded after 14.0ms using 1361KB peak memory
deserialized and retained after 14.2ms using 23393KB peak memory
== cbor Vec<String>
serialized to 981837 bytes after 21.6ms using 20336KB peak memory
deserialized and discarded after 35.9ms using 1361KB peak memory
deserialized and retained after 32.7ms using 23393KB peak memory

== serde Vec<serde_json::Value>
serialized to 1045641 bytes after 36.0ms using 72310KB peak memory
deserialized and discarded after 23.8ms using 1459KB peak memory
deserialized and retained after 29.2ms using 72798KB peak memory
== msgpack Vec<serde_json::Value>
serialized to 978684 bytes after 24.6ms using 72310KB peak memory
deserialized and discarded after 18.0ms using 1350KB peak memory
deserialized and retained after 19.7ms using 72688KB peak memory
== cbor Vec<serde_json::Value>
serialized to 976419 bytes after 24.6ms using 72310KB peak memory
deserialized and discarded after 24.1ms using 1350KB peak memory
deserialized and retained after 26.3ms using 72689KB peak memory

== serde Vec<HashMap<String, String>>
serialized to 1203788 bytes after 35.6ms using 34114KB peak memory
deserialized and discarded after 25.2ms using 1715KB peak memory
deserialized and retained after 26.9ms using 33306KB peak memory
== msgpack Vec<HashMap<String, String>>
serialized to 1178246 bytes after 25.5ms using 34114KB peak memory
deserialized and discarded after 18.9ms using 1768KB peak memory
deserialized and retained after 19.7ms using 33359KB peak memory
== cbor Vec<HashMap<String, String>>
serialized to 1178502 bytes after 25.8ms using 34114KB peak memory
deserialized and discarded after 26.3ms using 1782KB peak memory
deserialized and retained after 28.2ms using 33372KB peak memory

== serde Vec<BTreeMap<String, String>>
serialized to 1045641 bytes after 33.8ms using 64245KB peak memory
deserialized and discarded after 22.7ms using 1459KB peak memory
deserialized and retained after 24.3ms using 63180KB peak memory
== msgpack Vec<BTreeMap<String, String>>
serialized to 978684 bytes after 23.9ms using 64245KB peak memory
deserialized and discarded after 17.2ms using 1349KB peak memory
deserialized and retained after 18.8ms using 63071KB peak memory
== cbor Vec<BTreeMap<String, String>>
serialized to 976419 bytes after 24.5ms using 64245KB peak memory
deserialized and discarded after 25.6ms using 1350KB peak memory
deserialized and retained after 27.4ms using 63072KB peak memory

== serde Vec<IndexMap<String, String>>
serialized to 1045641 bytes after 34.7ms using 32499KB peak memory
deserialized and discarded after 27.1ms using 1458KB peak memory
deserialized and retained after 28.8ms using 36902KB peak memory
== msgpack Vec<IndexMap<String, String>>
serialized to 978684 bytes after 24.6ms using 32499KB peak memory
deserialized and discarded after 18.6ms using 1349KB peak memory
deserialized and retained after 20.2ms using 31324KB peak memory
== cbor Vec<IndexMap<String, String>>
serialized to 976419 bytes after 24.5ms using 32499KB peak memory
deserialized and discarded after 26.1ms using 1350KB peak memory
deserialized and retained after 29.1ms using 31325KB peak memory

== serde Vec<Struct>
serialized to 1020960 bytes after 43.5ms using 10901KB peak memory
deserialized and discarded after 17.6ms using 1539KB peak memory
deserialized and retained after 18.2ms using 14027KB peak memory
== msgpack Vec<Struct>
serialized to 1510627 bytes after 19.0ms using 11315KB peak memory
deserialized and discarded after 8.8ms using 2306KB peak memory
deserialized and retained after 8.9ms using 14794KB peak memory
== cbor Vec<Struct>
serialized to 1577733 bytes after 27.5ms using 11355KB peak memory
deserialized and discarded after 18.5ms using 2306KB peak memory
deserialized and retained after 19.4ms using 14794KB peak memory
```

</details>

<details><summary>Original <code>cargo bench --bench serialization</code> output including facet_postcard</summary>

```rs
== pco Vec<i64>
serialized to 273787 bytes after 7.9ms using 11465KB peak memory
deserialized and retained after 942.1µs using 7310KB peak memory
== serde Vec<i64>
serialized to 777214 bytes after 13.2ms using 5666KB peak memory
deserialized and discarded after 6.4ms using 1282KB peak memory
deserialized and retained after 6.5ms using 7426KB peak memory
== facet_postcard Vec<i64>
serialized to 1023896 bytes after 13.6ms using 5666KB peak memory
deserialized and discarded after 193.7ms using 1341KB peak memory
deserialized and retained after 192.0ms using 7429KB peak memory

== pco Vec<u64> + Vec<i64> (flattened)
serialized to 273830 bytes after 7.9ms using 12493KB peak memory
deserialized and retained after 2.2ms using 13205KB peak memory
== serde Vec<Vec<i64>>
serialized to 790233 bytes after 14.8ms using 5453KB peak memory
deserialized and discarded after 8.0ms using 1285KB peak memory
deserialized and retained after 8.2ms using 7941KB peak memory
== facet_postcard Vec<Vec<i64>>
serialized to 992779 bytes after 13.2ms using 5494KB peak memory
deserialized and discarded after 110.0ms using 1345KB peak memory
deserialized and retained after 110.1ms using 7944KB peak memory

== serde Vec<String>
serialized to 1043406 bytes after 30.9ms using 20342KB peak memory
deserialized and discarded after 18.6ms using 1467KB peak memory
deserialized and retained after 20.3ms using 23499KB peak memory
== facet_postcard Vec<String>
serialized to 980327 bytes after 37.9ms using 20342KB peak memory
deserialized and discarded after 264.8ms using 1367KB peak memory
deserialized and retained after 266.9ms using 23343KB peak memory

== serde Vec<serde_json::Value>
serialized to 1045641 bytes after 35.4ms using 72319KB peak memory
deserialized and discarded after 23.6ms using 1468KB peak memory
deserialized and retained after 28.8ms using 72806KB peak memory
== facet_postcard Vec<facet_value::Value>
serialized to 985318 bytes after 31.7ms using 18946KB peak memory
deserialized and discarded after 118.4ms using 1421KB peak memory
deserialized and retained after 119.5ms using 20324KB peak memory

== serde Vec<HashMap<String, String>>
serialized to 1204478 bytes after 34.9ms using 34126KB peak memory
deserialized and discarded after 24.9ms using 1717KB peak memory
deserialized and retained after 27.6ms using 33307KB peak memory
== facet_postcard Vec<HashMap<String, String>>
serialized to 1171748 bytes after 36.1ms using 34126KB peak memory
deserialized and discarded after 132.7ms using 1822KB peak memory
deserialized and retained after 130.8ms using 33413KB peak memory

== serde Vec<BTreeMap<String, String>>
serialized to 1045641 bytes after 32.6ms using 64260KB peak memory
deserialized and discarded after 22.3ms using 1473KB peak memory
deserialized and retained after 24.1ms using 63194KB peak memory
== facet_postcard Vec<BTreeMap<String, String>>
serialized to 975543 bytes after 34.0ms using 64260KB peak memory
deserialized and discarded after 127.1ms using 1391KB peak memory
deserialized and retained after 129.1ms using 63112KB peak memory

== serde Vec<IndexMap<String, String>>
serialized to 1045641 bytes after 33.2ms using 32516KB peak memory
deserialized and discarded after 25.3ms using 1476KB peak memory
deserialized and retained after 32.8ms using 36919KB peak memory

== serde Vec<Struct>
serialized to 1020960 bytes after 38.9ms using 10918KB peak memory
deserialized and discarded after 17.4ms using 1557KB peak memory
deserialized and retained after 18.4ms using 14045KB peak memory
== facet_postcard Vec<Struct>
serialized to 1353912 bytes after 41.9ms using 11036KB peak memory
deserialized and discarded after 95.2ms using 2387KB peak memory
deserialized and retained after 95.4ms using 14817KB peak memory