### PR TITLE
Use pco compression for nested numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,7 @@ dependencies = [
  "quote",
  "rmp-serde",
  "serde",
+ "serde_bytes",
  "serde_json",
  "serde_with",
  "serial_test",
@@ -1070,6 +1071,16 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 rmp-serde = "1.3"
 serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
 serde_json = { version = "1.0" }
 serde_with = "3.16"
 syn = "2.0"

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ To see the generated code, look in [tests/expand](tests/expand) or run `cargo ex
 
 pco supports `u16`, `u32`, `u64`, `i16`, `i32`, `i64`, `f16`, `f32`, `f64`
 
-pco_store converts these data types into numbers in order to use pco compression:
-- `chrono::DateTime`, `std::time::SystemTime`
+pco_store converts these data types into numbers so they can be compressed with pco:
+- `chrono::DateTime` and `std::time::SystemTime`, stored as microsecond offsets from the Unix epoch
+- `Vec<{number}>`, stored as a flat array with the length of each nested array for later rebuilding the nested structure
 - `bool`
 
 Any other serde-compatible data type will be serialized with MessagePack and compressed with zstd. Note:
 - At read time, these fields are incrementally decompressed to reduce peak memory usage, assuming the provided filter discards most rows
 - Maps should use `BTreeMap` or `IndexMap` instead of `HashMap`, because random key order hurts compression
 - MessagePack doesn't support adding new fields to tuples, so changing a field's type from `(bool)` to `(bool, i32)` will break. Use a struct to avoid this issue
-- A future breaking change will flatten `Vec<{number}>` so they can be pco-compressed
 - A future breaking change will compress UUIDs stored as a non-`group_by` field, assuming timestamp-prefixed UUIDs are used and so can be pco-compressed
 
 ## Performance

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -36,6 +36,10 @@ pub fn generate(
                     };
                 });
                 compressed_field_sizes.push(quote! { #ident.len(), });
+            } else if is_nested_number(&ty) {
+                decompress_fields.push(quote! {
+                    let mut #ident: std::vec::IntoIter<#ty> = pco_decompress_nested(self.#ident)?.into_iter();
+                });
             } else {
                 decompress_fields.push(quote! {
                     let mut #ident = serde_decompress::<#ty>(&self.#ident);
@@ -43,6 +47,8 @@ pub fn generate(
             }
             let value = if is_number(&ty) {
                 quote! { #ident.get(index).cloned().unwrap_or_default() }
+            } else if is_nested_number(&ty) {
+                quote! { #ident.next().unwrap_or_default() }
             } else {
                 quote! { #ident.next().transpose()?.unwrap_or_default() }
             };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,23 @@ pub fn store(args: TokenStream, item: TokenStream) -> TokenStream {
 fn is_number(ty: &Type) -> bool {
     let ty = quote! { #ty }.to_string();
     match ty.as_str() {
-        "u8" | "u16" | "u32" | "u64" | "i8" | "i16" | "i32" | "i64" | "f32" | "f64" | "bool" => true,
+        "u8" | "u16" | "u32" | "u64" => true,
+        "i8" | "i16" | "i32" | "i64" => true,
+        "f32" | "f64" => true,
+        "bool" => true,
+        _ => false,
+    }
+}
+
+fn is_nested_number(ty: &Type) -> bool {
+    let ty = quote! { #ty }.to_string();
+    // Remove syn's added spacing, turning "Vec < i32 >" into "Vec<i32>"
+    let ty = ty.replace(" < ", "<").replace(" >", ">");
+    match ty.as_str() {
+        "Vec<u8>" | "Vec<u16>" | "Vec<u32>" | "Vec<u64>" => true,
+        "Vec<i8>" | "Vec<i16>" | "Vec<i32>" | "Vec<i64>" => true,
+        "Vec<f32>" | "Vec<f64>" => true,
+        "Vec<bool>" => true,
         _ => false,
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -31,5 +31,34 @@ pub fn generate() -> proc_macro2::TokenStream {
                 Err(e) => Some(Err(e.into())),
             }))
         }
+        fn pco_compress_nested<T>(nested_values: Vec<Vec<T>>) -> anyhow::Result<Vec<u8>>
+        where
+            T: ::pco::data_types::Number,
+        {
+            let mut lengths = Vec::new();
+            let mut values = Vec::new();
+            for vals in nested_values {
+                lengths.push(vals.len() as u64);
+                values.extend(vals);
+            }
+            let length_bytes = ::pco::standalone::simpler_compress(&lengths, ::pco::DEFAULT_COMPRESSION_LEVEL)?;
+            let value_bytes = ::pco::standalone::simpler_compress(&values, ::pco::DEFAULT_COMPRESSION_LEVEL)?;
+            let (length_bytes, value_bytes) = (serde_bytes::Bytes::new(&length_bytes), serde_bytes::Bytes::new(&value_bytes));
+            Ok(rmp_serde::to_vec(&(length_bytes, value_bytes))?)
+        }
+        fn pco_decompress_nested<T>(bytes: Vec<u8>) -> anyhow::Result<Vec<Vec<T>>>
+        where
+            T: ::pco::data_types::Number,
+        {
+            let (length_bytes, value_bytes): (Vec<u8>, Vec<u8>) = rmp_serde::from_slice(&bytes)?;
+            let lengths = ::pco::standalone::simple_decompress::<u64>(&length_bytes)?;
+            let values = ::pco::standalone::simple_decompress::<T>(&value_bytes)?;
+            let mut values = values.into_iter();
+            let mut nested_values = Vec::with_capacity(lengths.len());
+            for length in lengths {
+                nested_values.push(values.by_ref().take(length as usize).collect::<Vec<T>>());
+            }
+            Ok(nested_values)
+        }
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -39,36 +39,34 @@ pub fn generate(
                 &start_at, &end_at,
                 &::pco::standalone::simpler_compress(&#timestamp, ::pco::DEFAULT_COMPRESSION_LEVEL).unwrap(),
             });
-        } else if is_number(&ty) {
+        } else if is_number(&ty) || is_nested_number(&ty) {
             store_fields.push(ident.to_string());
             store_types.push(Ident::new("BYTEA", Span::call_site()));
-            let expr = if round_float_field {
-                quote! { (r.#ident * #float_round as #ty_original).round() as i64 }
-            } else if quote! { #ty_original }.to_string() == "bool" {
-                quote! { r.#ident as u16 }
-            } else {
+            let val = if is_number(&ty) {
                 quote! { r.#ident }
-            };
-            store_values.push(quote! {
-                &::pco::standalone::simpler_compress(
-                    &rows.iter().map(|r| #expr).collect::<Vec<_>>(), ::pco::DEFAULT_COMPRESSION_LEVEL
-                )?,
-            });
-        } else if is_nested_number(&ty) {
-            store_fields.push(ident.to_string());
-            store_types.push(Ident::new("BYTEA", Span::call_site()));
-            let expr = if round_float_field {
-                quote! { (v * #float_round as #ty_original).round() as i64 }
-            } else if quote! { #ty_original }.to_string() == "bool" {
-                quote! { v as u16 }
             } else {
-                quote! { v }
+                quote! { v } // Closure argument inside of nested `map`
             };
-            store_values.push(quote! {
-                &pco_compress_nested(
-                    rows.iter().map(|r| r.#ident.iter().map(|v| *#expr).collect::<Vec<_>>()).collect::<Vec<_>>()
-                )?,
-            });
+            let expr = if round_float_field {
+                quote! { (#val * #float_round as #ty_original).round() as i64 }
+            } else if quote! { #ty_original }.to_string() == "bool" {
+                quote! { #val as u16 }
+            } else {
+                quote! { #val }
+            };
+            if is_number(&ty) {
+                store_values.push(quote! {
+                    &::pco::standalone::simpler_compress(
+                        &rows.iter().map(|r| #expr).collect::<Vec<_>>(), ::pco::DEFAULT_COMPRESSION_LEVEL
+                    )?,
+                });
+            } else {
+                store_values.push(quote! {
+                    &pco_compress_nested(
+                        rows.iter().map(|r| r.#ident.iter().map(|v| *#expr).collect::<Vec<_>>()).collect::<Vec<_>>()
+                    )?,
+                });
+            }
         } else {
             store_fields.push(ident.to_string());
             store_types.push(Ident::new("BYTEA", Span::call_site()));

--- a/src/store.rs
+++ b/src/store.rs
@@ -54,6 +54,21 @@ pub fn generate(
                     &rows.iter().map(|r| #expr).collect::<Vec<_>>(), ::pco::DEFAULT_COMPRESSION_LEVEL
                 )?,
             });
+        } else if is_nested_number(&ty) {
+            store_fields.push(ident.to_string());
+            store_types.push(Ident::new("BYTEA", Span::call_site()));
+            let expr = if round_float_field {
+                quote! { (v * #float_round as #ty_original).round() as i64 }
+            } else if quote! { #ty_original }.to_string() == "bool" {
+                quote! { v as u16 }
+            } else {
+                quote! { v }
+            };
+            store_values.push(quote! {
+                &pco_compress_nested(
+                    rows.iter().map(|r| r.#ident.iter().map(|v| *#expr).collect::<Vec<_>>()).collect::<Vec<_>>()
+                )?,
+            });
         } else {
             store_fields.push(ident.to_string());
             store_types.push(Ident::new("BYTEA", Span::call_site()));

--- a/tests/expand/boolean.expanded.rs
+++ b/tests/expand/boolean.expanded.rs
@@ -937,3 +937,41 @@ where
         }),
     )
 }
+fn pco_compress_nested<T>(nested_values: Vec<Vec<T>>) -> anyhow::Result<Vec<u8>>
+where
+    T: ::pco::data_types::Number,
+{
+    let mut lengths = Vec::new();
+    let mut values = Vec::new();
+    for vals in nested_values {
+        lengths.push(vals.len() as u64);
+        values.extend(vals);
+    }
+    let length_bytes = ::pco::standalone::simpler_compress(
+        &lengths,
+        ::pco::DEFAULT_COMPRESSION_LEVEL,
+    )?;
+    let value_bytes = ::pco::standalone::simpler_compress(
+        &values,
+        ::pco::DEFAULT_COMPRESSION_LEVEL,
+    )?;
+    let (length_bytes, value_bytes) = (
+        serde_bytes::Bytes::new(&length_bytes),
+        serde_bytes::Bytes::new(&value_bytes),
+    );
+    Ok(rmp_serde::to_vec(&(length_bytes, value_bytes))?)
+}
+fn pco_decompress_nested<T>(bytes: Vec<u8>) -> anyhow::Result<Vec<Vec<T>>>
+where
+    T: ::pco::data_types::Number,
+{
+    let (length_bytes, value_bytes): (Vec<u8>, Vec<u8>) = rmp_serde::from_slice(&bytes)?;
+    let lengths = ::pco::standalone::simple_decompress::<u64>(&length_bytes)?;
+    let values = ::pco::standalone::simple_decompress::<T>(&value_bytes)?;
+    let mut values = values.into_iter();
+    let mut nested_values = Vec::with_capacity(lengths.len());
+    for length in lengths {
+        nested_values.push(values.by_ref().take(length as usize).collect::<Vec<T>>());
+    }
+    Ok(nested_values)
+}

--- a/tests/expand/float_round.expanded.rs
+++ b/tests/expand/float_round.expanded.rs
@@ -944,3 +944,41 @@ where
         }),
     )
 }
+fn pco_compress_nested<T>(nested_values: Vec<Vec<T>>) -> anyhow::Result<Vec<u8>>
+where
+    T: ::pco::data_types::Number,
+{
+    let mut lengths = Vec::new();
+    let mut values = Vec::new();
+    for vals in nested_values {
+        lengths.push(vals.len() as u64);
+        values.extend(vals);
+    }
+    let length_bytes = ::pco::standalone::simpler_compress(
+        &lengths,
+        ::pco::DEFAULT_COMPRESSION_LEVEL,
+    )?;
+    let value_bytes = ::pco::standalone::simpler_compress(
+        &values,
+        ::pco::DEFAULT_COMPRESSION_LEVEL,
+    )?;
+    let (length_bytes, value_bytes) = (
+        serde_bytes::Bytes::new(&length_bytes),
+        serde_bytes::Bytes::new(&value_bytes),
+    );
+    Ok(rmp_serde::to_vec(&(length_bytes, value_bytes))?)
+}
+fn pco_decompress_nested<T>(bytes: Vec<u8>) -> anyhow::Result<Vec<Vec<T>>>
+where
+    T: ::pco::data_types::Number,
+{
+    let (length_bytes, value_bytes): (Vec<u8>, Vec<u8>) = rmp_serde::from_slice(&bytes)?;
+    let lengths = ::pco::standalone::simple_decompress::<u64>(&length_bytes)?;
+    let values = ::pco::standalone::simple_decompress::<T>(&value_bytes)?;
+    let mut values = values.into_iter();
+    let mut nested_values = Vec::with_capacity(lengths.len());
+    for length in lengths {
+        nested_values.push(values.by_ref().take(length as usize).collect::<Vec<T>>());
+    }
+    Ok(nested_values)
+}

--- a/tests/expand/no_group_by.expanded.rs
+++ b/tests/expand/no_group_by.expanded.rs
@@ -934,3 +934,41 @@ where
         }),
     )
 }
+fn pco_compress_nested<T>(nested_values: Vec<Vec<T>>) -> anyhow::Result<Vec<u8>>
+where
+    T: ::pco::data_types::Number,
+{
+    let mut lengths = Vec::new();
+    let mut values = Vec::new();
+    for vals in nested_values {
+        lengths.push(vals.len() as u64);
+        values.extend(vals);
+    }
+    let length_bytes = ::pco::standalone::simpler_compress(
+        &lengths,
+        ::pco::DEFAULT_COMPRESSION_LEVEL,
+    )?;
+    let value_bytes = ::pco::standalone::simpler_compress(
+        &values,
+        ::pco::DEFAULT_COMPRESSION_LEVEL,
+    )?;
+    let (length_bytes, value_bytes) = (
+        serde_bytes::Bytes::new(&length_bytes),
+        serde_bytes::Bytes::new(&value_bytes),
+    );
+    Ok(rmp_serde::to_vec(&(length_bytes, value_bytes))?)
+}
+fn pco_decompress_nested<T>(bytes: Vec<u8>) -> anyhow::Result<Vec<Vec<T>>>
+where
+    T: ::pco::data_types::Number,
+{
+    let (length_bytes, value_bytes): (Vec<u8>, Vec<u8>) = rmp_serde::from_slice(&bytes)?;
+    let lengths = ::pco::standalone::simple_decompress::<u64>(&length_bytes)?;
+    let values = ::pco::standalone::simple_decompress::<T>(&value_bytes)?;
+    let mut values = values.into_iter();
+    let mut nested_values = Vec::with_capacity(lengths.len());
+    for length in lengths {
+        nested_values.push(values.by_ref().take(length as usize).collect::<Vec<T>>());
+    }
+    Ok(nested_values)
+}

--- a/tests/expand/query_stats.expanded.rs
+++ b/tests/expand/query_stats.expanded.rs
@@ -2296,3 +2296,41 @@ where
         }),
     )
 }
+fn pco_compress_nested<T>(nested_values: Vec<Vec<T>>) -> anyhow::Result<Vec<u8>>
+where
+    T: ::pco::data_types::Number,
+{
+    let mut lengths = Vec::new();
+    let mut values = Vec::new();
+    for vals in nested_values {
+        lengths.push(vals.len() as u64);
+        values.extend(vals);
+    }
+    let length_bytes = ::pco::standalone::simpler_compress(
+        &lengths,
+        ::pco::DEFAULT_COMPRESSION_LEVEL,
+    )?;
+    let value_bytes = ::pco::standalone::simpler_compress(
+        &values,
+        ::pco::DEFAULT_COMPRESSION_LEVEL,
+    )?;
+    let (length_bytes, value_bytes) = (
+        serde_bytes::Bytes::new(&length_bytes),
+        serde_bytes::Bytes::new(&value_bytes),
+    );
+    Ok(rmp_serde::to_vec(&(length_bytes, value_bytes))?)
+}
+fn pco_decompress_nested<T>(bytes: Vec<u8>) -> anyhow::Result<Vec<Vec<T>>>
+where
+    T: ::pco::data_types::Number,
+{
+    let (length_bytes, value_bytes): (Vec<u8>, Vec<u8>) = rmp_serde::from_slice(&bytes)?;
+    let lengths = ::pco::standalone::simple_decompress::<u64>(&length_bytes)?;
+    let values = ::pco::standalone::simple_decompress::<T>(&value_bytes)?;
+    let mut values = values.into_iter();
+    let mut nested_values = Vec::with_capacity(lengths.len());
+    for length in lengths {
+        nested_values.push(values.by_ref().take(length as usize).collect::<Vec<T>>());
+    }
+    Ok(nested_values)
+}

--- a/tests/expand/query_stats_chrono.expanded.rs
+++ b/tests/expand/query_stats_chrono.expanded.rs
@@ -2282,3 +2282,41 @@ where
         }),
     )
 }
+fn pco_compress_nested<T>(nested_values: Vec<Vec<T>>) -> anyhow::Result<Vec<u8>>
+where
+    T: ::pco::data_types::Number,
+{
+    let mut lengths = Vec::new();
+    let mut values = Vec::new();
+    for vals in nested_values {
+        lengths.push(vals.len() as u64);
+        values.extend(vals);
+    }
+    let length_bytes = ::pco::standalone::simpler_compress(
+        &lengths,
+        ::pco::DEFAULT_COMPRESSION_LEVEL,
+    )?;
+    let value_bytes = ::pco::standalone::simpler_compress(
+        &values,
+        ::pco::DEFAULT_COMPRESSION_LEVEL,
+    )?;
+    let (length_bytes, value_bytes) = (
+        serde_bytes::Bytes::new(&length_bytes),
+        serde_bytes::Bytes::new(&value_bytes),
+    );
+    Ok(rmp_serde::to_vec(&(length_bytes, value_bytes))?)
+}
+fn pco_decompress_nested<T>(bytes: Vec<u8>) -> anyhow::Result<Vec<Vec<T>>>
+where
+    T: ::pco::data_types::Number,
+{
+    let (length_bytes, value_bytes): (Vec<u8>, Vec<u8>) = rmp_serde::from_slice(&bytes)?;
+    let lengths = ::pco::standalone::simple_decompress::<u64>(&length_bytes)?;
+    let values = ::pco::standalone::simple_decompress::<T>(&value_bytes)?;
+    let mut values = values.into_iter();
+    let mut nested_values = Vec::with_capacity(lengths.len());
+    for length in lengths {
+        nested_values.push(values.by_ref().take(length as usize).collect::<Vec<T>>());
+    }
+    Ok(nested_values)
+}

--- a/tests/expand/serde.expanded.rs
+++ b/tests/expand/serde.expanded.rs
@@ -763,7 +763,8 @@ impl CompressedSerdes {
         };
         let mut description = serde_decompress::<String>(&self.description);
         let mut tags = serde_decompress::<Vec<String>>(&self.tags);
-        let mut nums = serde_decompress::<Vec<i32>>(&self.nums);
+        let mut nums: std::vec::IntoIter<Vec<i32>> = pco_decompress_nested(self.nums)?
+            .into_iter();
         let mut map = serde_decompress::<BTreeMap<String, String>>(&self.map);
         let mut json = serde_decompress::<serde_json::Value>(&self.json);
         let mut model = serde_decompress::<Option<Box<Serde>>>(&self.model);
@@ -778,7 +779,7 @@ impl CompressedSerdes {
                     .unwrap(),
                 description: description.next().transpose()?.unwrap_or_default(),
                 tags: tags.next().transpose()?.unwrap_or_default(),
-                nums: nums.next().transpose()?.unwrap_or_default(),
+                nums: nums.next().unwrap_or_default(),
                 map: map.next().transpose()?.unwrap_or_default(),
                 json: json.next().transpose()?.unwrap_or_default(),
                 model: model.next().transpose()?.unwrap_or_default(),
@@ -855,8 +856,11 @@ impl CompressedSerdes {
                         &serde_compress(
                             rows.iter().map(|r| r.tags.clone()).collect::<Vec<_>>(),
                         )?,
-                        &serde_compress(
-                            rows.iter().map(|r| r.nums.clone()).collect::<Vec<_>>(),
+                        &pco_compress_nested(
+                            rows
+                                .iter()
+                                .map(|r| r.nums.iter().map(|v| *v).collect::<Vec<_>>())
+                                .collect::<Vec<_>>(),
                         )?,
                         &serde_compress(
                             rows.iter().map(|r| r.map.clone()).collect::<Vec<_>>(),
@@ -948,8 +952,11 @@ impl CompressedSerdes {
                         &serde_compress(
                             rows.iter().map(|r| r.tags.clone()).collect::<Vec<_>>(),
                         )?,
-                        &serde_compress(
-                            rows.iter().map(|r| r.nums.clone()).collect::<Vec<_>>(),
+                        &pco_compress_nested(
+                            rows
+                                .iter()
+                                .map(|r| r.nums.iter().map(|v| *v).collect::<Vec<_>>())
+                                .collect::<Vec<_>>(),
                         )?,
                         &serde_compress(
                             rows.iter().map(|r| r.map.clone()).collect::<Vec<_>>(),
@@ -2568,4 +2575,42 @@ where
             Err(e) => Some(Err(e.into())),
         }),
     )
+}
+fn pco_compress_nested<T>(nested_values: Vec<Vec<T>>) -> anyhow::Result<Vec<u8>>
+where
+    T: ::pco::data_types::Number,
+{
+    let mut lengths = Vec::new();
+    let mut values = Vec::new();
+    for vals in nested_values {
+        lengths.push(vals.len() as u64);
+        values.extend(vals);
+    }
+    let length_bytes = ::pco::standalone::simpler_compress(
+        &lengths,
+        ::pco::DEFAULT_COMPRESSION_LEVEL,
+    )?;
+    let value_bytes = ::pco::standalone::simpler_compress(
+        &values,
+        ::pco::DEFAULT_COMPRESSION_LEVEL,
+    )?;
+    let (length_bytes, value_bytes) = (
+        serde_bytes::Bytes::new(&length_bytes),
+        serde_bytes::Bytes::new(&value_bytes),
+    );
+    Ok(rmp_serde::to_vec(&(length_bytes, value_bytes))?)
+}
+fn pco_decompress_nested<T>(bytes: Vec<u8>) -> anyhow::Result<Vec<Vec<T>>>
+where
+    T: ::pco::data_types::Number,
+{
+    let (length_bytes, value_bytes): (Vec<u8>, Vec<u8>) = rmp_serde::from_slice(&bytes)?;
+    let lengths = ::pco::standalone::simple_decompress::<u64>(&length_bytes)?;
+    let values = ::pco::standalone::simple_decompress::<T>(&value_bytes)?;
+    let mut values = values.into_iter();
+    let mut nested_values = Vec::with_capacity(lengths.len());
+    for length in lengths {
+        nested_values.push(values.by_ref().take(length as usize).collect::<Vec<T>>());
+    }
+    Ok(nested_values)
 }

--- a/tests/serde_tests/mod.rs
+++ b/tests/serde_tests/mod.rs
@@ -56,11 +56,13 @@ async fn string() -> anyhow::Result<()> {
         db.batch_execute(sql).await?;
 
         let a =
-            Model { id, name: "a".into(), description: "desc".into(), tags: vec!["y".into(), "z".into()], nums: vec![9, 10], ..Default::default() };
+            Model { id, name: "a".into(), description: "desc".into(), tags: vec!["x".into(), "y".into()], nums: vec![8, 9], ..Default::default() };
         let a1 = Model { id, time: t, ..a.clone() };
         let a2 = Model {
             id,
             time: t2,
+            tags: vec!["x".into(), "y".into(), "z".into()],
+            nums: vec![8, 9, 10],
             description: "other".into(),
             map: [("k".into(), "v".into())].into(),
             json: json!(null),


### PR DESCRIPTION
For #8, on top of of #52 and #54.

For structs that contain numeric arrays like `Vec<i64>`, this PR allows us to make use of pco compression by splitting up the data into a `Vec<u64>` for the length of each nested array, with the flat values stored in an `Vec<i64>`. During deserialization we recombine them into the original nested structure.

[As covered in the benchmark](https://github.com/pganalyze/pco_store/pull/52#discussion_r3058766248), this structure enables >3x smaller compressed size at the cost using 2x more memory during serialization and deserialization.

```rs
== pco + msgpack Vec<u64> + Vec<i64> (flattened)
serialized to 273822 bytes after 7.7ms using 12489KB peak memory
deserialized and retained after 2.6ms using 13792KB peak memory
== msgpack Vec<Vec<i64>>
serialized to 899317 bytes after 10.0ms using 5777KB peak memory
deserialized and discarded after 3.2ms using 1282KB peak memory
deserialized and retained after 3.4ms using 7426KB peak memory